### PR TITLE
Switch to python:rc-slim to get python3.9 with the new graphlib

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,11 @@
 FROM python:rc-slim
 ADD appgate /root/appgate/
 ADD requirements.txt /root/
-RUN python3 -m venv /root/venv && \
-    /root/venv/bin/pip install -r /root/requirements.txt
+RUN apt-get update && \
+    apt-get install gcc --yes && \
+    python3 -m venv /root/venv && \
+    /root/venv/bin/pip install -r /root/requirements.txt && \
+    apt-get autoremove gcc --yes
 WORKDIR /root
 
 ENTRYPOINT /root/venv/bin/python3 -m appgate


### PR DESCRIPTION
This allows us to use the new stdlib module graphlib to do topoligical sorting of entities.
Once python3.9 is out we can switch back to `python:slim`.

https://docs.python.org/3.9/library/graphlib.html