### PR TITLE
Iterate over the entities in topological order when applying plan

### DIFF
--- a/appgate/appgate.py
+++ b/appgate/appgate.py
@@ -304,7 +304,8 @@ async def main_loop(queue: Queue, ctx: Context, k8s_configmap_client: K8SConfigM
                                                             api_spec=ctx.api_spec,
                                                             appgate_client=appgate_client)
                                                         if appgate_client else {},
-                                                        k8s_configmap_client=k8s_configmap_client)
+                                                        k8s_configmap_client=k8s_configmap_client,
+                                                        api_spec=ctx.api_spec)
 
                     if appgate_client:
                         current_appgate_state = new_plan.appgate_state


### PR DESCRIPTION
Applies the plan in topological order. As it's computed by the openapi specification parser.

Fixes #57 