### PR TITLE
Add support for custom certificates

### DIFF
--- a/README.org
+++ b/README.org
@@ -252,6 +252,8 @@ Before deploying it MUST define these env variables:
    controller.
  - APPGATE_OPERATOR_PASSWORD :: the password used to authenticate the REST calls
    to the controller.
+
+Optional environment variables that the operator uses:
  - APPGATE_OPERATOR_TIMEOUT :: Time without activity after which the appgate
    operator will try to apply changes received into a plan. Every time a new
    event is received this timer is reset to 0 again.
@@ -282,6 +284,10 @@ Before deploying it MUST define these env variables:
  - APPGATE_OPERATOR_SSL_NO_VERIFY :: When set to 1 the operator won't verify the
    validity of the SSL cerficate. Use this if you have a self signed
    certificate. Not recommended on production. Default value is 0.
+ - APPGATE_OPERATOR_CACERT :: Base64 encoded CA certificate used by controllers
+   in the appgate system. The certifacate must be base64 encoded in one
+   line. Example:
+ : =cat cert.ca | base64 -w0=
       
 *** Configuration when runinng the operator locally
 In the case we run it locally for testing we only need to export those

--- a/appgate/__main__.py
+++ b/appgate/__main__.py
@@ -160,15 +160,16 @@ def main() -> None:
             dry_run=args.dry_run, user=args.user, password=args.password,
             host=args.host, two_way_sync=args.two_way_sync, target_tags=args.tags,
             cleanup=args.cleanup, timeout=args.timeout, metadata_configmap=args.mt_config_map,
-            no_verify=args.no_verify, cafile=Path(args.cafile)))
+            no_verify=args.no_verify, cafile=Path(args.cafile) if args.cafile else None))
     elif args.cmd == 'dump-entities':
         if args.cafile and not Path(args.cafile).exists():
             print(f'cafile file not found: {args.cafile}')
             sys.exit(1)
+
         main_dump_entities(
             OperatorArguments(namespace='cli', spec_directory=args.spec_directory,
                               target_tags=args.tags, no_verify=args.no_verify,
-                              cafile=Path(args.cafile)),
+                              cafile=Path(args.cafile) if args.cafile else None),
             stdout=args.stdout,
             output_dir=Path(args.directory) if args.directory else None)
     elif args.cmd == 'dump-crd':

--- a/appgate/appgate.py
+++ b/appgate/appgate.py
@@ -112,6 +112,8 @@ def get_context(args: OperatorArguments,
     appgate_cacert_path = None
     if no_verify != '1' and appgate_cacert:
         appgate_cacert_path = save_cert(appgate_cacert)
+    elif no_verify and args.cafile:
+        appgate_cacert_path = args.cafile
     secrets_key = os.getenv(APPGATE_SECRETS_KEY)
     target_tags_arg = frozenset(args.target_tags) if args.target_tags else frozenset()
     target_tags_env = target_tags_arg.union(
@@ -137,7 +139,7 @@ def get_context(args: OperatorArguments,
                    no_verify=no_verify == '1',
                    target_tags=target_tags_env if target_tags_env else None,
                    metadata_configmap=metadata_configmap,
-                   cert_path=appgate_cacert_path)
+                   cafile=appgate_cacert_path)
 
 
 def init_kubernetes(args: OperatorArguments) -> Context:

--- a/appgate/appgate.py
+++ b/appgate/appgate.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import itertools
 import logging
 import os
@@ -86,10 +87,14 @@ class Context:
 
 
 def save_cert(cert: str) -> Path:
+    try:
+        bytes_decoded: bytes = base64.b64decode(cert)
+    except Exception as e:
+        raise Exception(f'Error decoding PEM certificate: {str(e)}')
     fd, cert_name = tempfile.mkstemp()
     cert_path = Path(cert_name)
-    with cert_path.open() as f:
-        f.write(cert)
+    with cert_path.open('w') as f:
+        f.write(bytes_decoded.decode())
     os.close(fd)
     return cert_path
 

--- a/appgate/client.py
+++ b/appgate/client.py
@@ -1,6 +1,8 @@
 import asyncio
 import datetime
+import ssl
 import uuid
+from pathlib import Path
 from typing import Dict, Any, Optional, List, Callable
 import aiohttp
 from aiohttp import InvalidURL
@@ -172,7 +174,7 @@ class K8SConfigMapClient:
 
 class AppgateClient:
     def __init__(self, controller: str, user: str, password: str, version: int,
-                 no_verify: bool = False) -> None:
+                 no_verify: bool = False, cafile: Optional[Path] = None) -> None:
         self.controller = controller
         self.user = user
         self.password = password
@@ -181,6 +183,7 @@ class AppgateClient:
         self._token = None
         self.version = version
         self.no_verify = no_verify
+        self.ssl_context = ssl.create_default_context(cafile=str(cafile)) if cafile else None
 
 
     async def close(self) -> None:
@@ -221,7 +224,7 @@ class AppgateClient:
             async with method(url=url,  # type: ignore
                               headers=headers,
                               json=data,
-                              ssl=not self.no_verify) as resp:
+                              ssl=self.ssl_context or not self.no_verify) as resp:
                 status_code = resp.status // 100
                 if status_code == 2:
                     if resp.status == 204:

--- a/appgate/client.py
+++ b/appgate/client.py
@@ -224,7 +224,8 @@ class AppgateClient:
             async with method(url=url,  # type: ignore
                               headers=headers,
                               json=data,
-                              ssl=self.ssl_context or not self.no_verify) as resp:
+                              ssl=self.ssl_context,
+                              verify_ssl=not self.no_verify) as resp:
                 status_code = resp.status // 100
                 if status_code == 2:
                     if resp.status == 204:

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -1,4 +1,5 @@
 import datetime
+from pathlib import Path
 from typing import Dict, Any, FrozenSet, Optional, List
 from attr import attrib, attrs, evolve
 
@@ -29,6 +30,7 @@ class OperatorArguments:
     target_tags: Optional[List[str]] = attrib(default=None)
     metadata_configmap: Optional[str] = attrib(default=None)
     no_verify: bool = attrib(default=False)
+    cafile: Optional[Path] = attrib(default=None)
 
 
 @attrs(slots=True, frozen=True)

--- a/manifests/01-config.yaml
+++ b/manifests/01-config.yaml
@@ -9,8 +9,16 @@ data:
   appgate-operator-cleanup: "1"
   appgate-operator-two-way-sync: "1"
   appgate-operator-ssl-no-verify: "0"
+
+  # Uncomment this to specify a custom CA certificate used to create the
+  # certificates provided by the appgate controllers
+  # VALUE is a base64 ca certificate in one line. Output from the command:
+  # `cat cacert | base64 -w0`
+  #appgate-operator-cacert "VALUE"
+  
   # Uncomment this if you want to use a FERNET key to decrypt secrets
   # appgate-operator-fernet-key "FERNET_KEY_VALUE"
+
   # Uncomment this if you want to replace the configmap store
   # used to save entities metadata
-  # appgate-operator-config-map
+  # appgate-operator-config-map "VALUE"

--- a/manifests/02-appgate-operator.yaml
+++ b/manifests/02-appgate-operator.yaml
@@ -58,6 +58,12 @@ spec:
                 configMapKeyRef:
                   name: appgate-operator-conf
                   key: appgate-operator-ssl-no-verify
+            # Uncomment if you have a self signed certificate in yout appgate collective
+            #- name: APPGATE_OPERATOR_CACERT
+            #  valueFrom:
+            #    configMapKeyRef:
+            #      name: appgate-operator-conf
+            #      key: appgate-operator-cacert
             # Uncomment if you want to use a FERNET key to decrypt secrets
             #- name: APPGATE_OPERATOR_FERNET_KEY
             #  valueFrom:


### PR DESCRIPTION
Self signed certificates can be now validated using:
 - argument `--cafile file`
 - environment variable `APPGATE_OPERATOR_CAFILE`

This is only used if `APPGATE_OPERATOR_NO_VERIFY` is not equal to 1.

Example usage:
`python3 -m appgate --spec-directory api_specs/v13/ dump-entities --cafile Appgate_SDP_envy-172-17-124-1.devops_CA.pem`

`APPGATE_OPERATOR_CACERT="$(cat Appgate_SDP_envy-172-17-124-1.devops_CA.pem|base64 -w0)" python3 -m appgate --spec-directory api_specs/v13/ dump-entities`