### PR TITLE
Make `format` field a string always in the openapi spec

### DIFF
--- a/api_specs/v12/appliance_customization.yml
+++ b/api_specs/v12/appliance_customization.yml
@@ -159,16 +159,14 @@ definitions:
           checksum:
             type: string
             readOnly: true
-            format:
-              type: checksum
-              source: file
+            format: checksum
+            x-checksum-source: file
             description: SHA256 checksum of the file.
             example: a0041669f6f7031d32bc27305955327abe54aeb03670c4ae1b2a48e5d29e8e33
           size:
             type: number
-            format:
-              type: size
-              source: file
+            format: size
+            x-size-source: file
             readOnly: true
             description: Binary file's size in bytes.
             example: 854325

--- a/api_specs/v12/ca.yml
+++ b/api_specs/v12/ca.yml
@@ -145,9 +145,8 @@ definitions:
     type: object
     description: X509 certificate details.
     readOnly: true
-    format:
-      type: certificate
-      source: pem
+    format: certificate
+    x-certificate-source: pem
     properties:
       version:
         type: number

--- a/api_specs/v12/device_script.yml
+++ b/api_specs/v12/device_script.yml
@@ -207,9 +207,8 @@ definitions:
               Deprecated as of 5.0. Use checksumSha256 field.
             example: 9a913c1e1eccf35e6e78542b2152f7a7
           checksumSha256:
-            format:
-              type: checksum
-              source: file
+            format: checksum
+            x-checksum-source: file
             type: string
             readOnly: true
             description: >-

--- a/api_specs/v12/site.yml
+++ b/api_specs/v12/site.yml
@@ -174,8 +174,7 @@ definitions:
             items:
               type: object
               properties:
-                fromm:
-                  x-name: from
+                from:
                   type: string
                   format: uuid
                   x-uuid-ref: IpPool

--- a/api_specs/v13/appliance_customization.yml
+++ b/api_specs/v13/appliance_customization.yml
@@ -160,16 +160,14 @@ definitions:
           checksum:
             type: string
             readOnly: true
-            format:
-              type: checksum
-              source: file
+            format: checksum
+            x-checksum-source: file
             description: SHA256 checksum of the file.
             example: a0041669f6f7031d32bc27305955327abe54aeb03670c4ae1b2a48e5d29e8e33
           size:
             type: number
-            format:
-              type: size
-              source: file
+            format: size
+            x-size-source: file
             readOnly: true
             description: Binary file's size in bytes.
             example: 854325

--- a/api_specs/v13/ca.yml
+++ b/api_specs/v13/ca.yml
@@ -159,9 +159,8 @@ definitions:
   CertificateDetails:
     type: object
     description: X509 certificate details.
-    format:
-      type: certificate
-      source: pem
+    format: certificate
+    x-certificate-source: pem
     readOnly: true
     properties:
       version:

--- a/api_specs/v13/device_script.yml
+++ b/api_specs/v13/device_script.yml
@@ -208,9 +208,8 @@ definitions:
               Deprecated as of 5.0. Use checksumSha256 field.
             example: 9a913c1e1eccf35e6e78542b2152f7a7
           checksumSha256:
-            format:
-              type: checksum
-              source: file
+            format: checksum
+            x-checksum-source: file
             type: string
             readOnly: true
             description: >-

--- a/api_specs/v13/entitlement.yml
+++ b/api_specs/v13/entitlement.yml
@@ -180,7 +180,7 @@ definitions:
             default: and
           conditions:
             type: array
-            description: List of Condition IDs applies to this Entitleent.
+            description: List of Condition IDs applies to this Entitlement.
             items:
               x-uuid-ref: Condition
               type: string

--- a/api_specs/v13/site.yml
+++ b/api_specs/v13/site.yml
@@ -178,11 +178,10 @@ definitions:
             items:
               type: object
               properties:
-                fromm:
+                from:
                   type: string
                   format: uuid
                   x-uuid-ref: IpPool
-                  x-name: from
                   description: >-
                     IP Pool ID to map from.
                     If a user is authorizing with this IP Pool via Identity Provider assignment and has access to this

--- a/appgate/openapi/parser.py
+++ b/appgate/openapi/parser.py
@@ -399,14 +399,14 @@ class Parser:
             log.debug('Created new attribute %s.%s of type %s', entity_name, attrib_name,
                       generated_entity.cls)
             format = definition.get('format', None)
-            if isinstance(format, dict) and 'type' in format and format['type'] == 'certificate':
+            if format == 'certificate' and 'x-certificate-source' in attrib_maker_config.definition:
                 return certificate_attrib_maker(name=instance_maker_config.name,
                                                 tpe=generated_entity.cls,
                                                 base_tpe=generated_entity.cls,
                                                 default=None,
                                                 factory=None,
                                                 definition=attrib_maker_config.definition,
-                                                source_field=format['source'],
+                                                source_field=attrib_maker_config.definition['x-certificate-source'],
                                                 loader=K8S_LOADER.load)
             else:
                 return SimpleAttribMaker(name=instance_maker_config.name,

--- a/appgate/openapi/parser.py
+++ b/appgate/openapi/parser.py
@@ -338,22 +338,22 @@ class Parser:
                                          default=None,
                                          factory=None,
                                          definition=attrib_maker_config.definition)
-            elif isinstance(format, dict) and 'type' in format and format['type'] == 'checksum':
+            elif format == 'checksum' and 'x-checksum-source' in attrib_maker_config.definition:
                 return checksum_attrib_maker(name=attrib_name,
                                              tpe=TYPES_MAP[tpe],
                                              base_tpe=TYPES_MAP[tpe],
                                              default=DEFAULT_MAP.get(tpe),
                                              factory=None,
                                              definition=attrib_maker_config.definition,
-                                             source_field=format['source'])
-            elif isinstance(format, dict) and 'type' in format and format['type'] == 'size':
+                                             source_field=attrib_maker_config.definition['x-checksum-source'])
+            elif format == 'size' and 'x-size-source' in attrib_maker_config.definition:
                 return size_attrib_maker(name=attrib_name,
                                          tpe=TYPES_MAP[tpe],
                                          base_tpe=TYPES_MAP[tpe],
                                          default=DEFAULT_MAP.get(tpe),
                                          factory=None,
                                          definition=attrib_maker_config.definition,
-                                         source_field=format['source'])
+                                         source_field=attrib_maker_config.definition['x-size-source'])
             elif attrib_name == 'id':
                 return IdAttribMaker(name=attrib_name,
                                      tpe=TYPES_MAP[tpe],

--- a/appgate/openapi/types.py
+++ b/appgate/openapi/types.py
@@ -61,8 +61,12 @@ APPGATE_METADATE_FIELDS = {
     APPGATE_METADATA_LATEST_GENERATION_FIELD,
 }
 
+RESERVED_NAMES = {'from'}
+
 
 def normalize_attrib_name(name: str) -> str:
+    if name in RESERVED_NAMES:
+        name = name + name[-1]
     if NAMES_REGEXP.match(name):
         return re.sub(r'\.', '_', name)
     return name
@@ -213,13 +217,12 @@ class InstanceMakerConfig:
     def attrib_maker_config(self, attribute: str) -> 'AttribMakerConfig':
         properties = self.definition.get('properties', {})
         definition = properties.get(attribute)
-        x_name = definition.get('x-name')
         if not definition:
             log.error('Unable to find attribute %s in %s', attribute, ', '.join(properties.keys()))
             raise OpenApiParserException(f'Unable to find attribute %s')
         return AttribMakerConfig(
             instance_maker_config=self,
-            name=normalize_attrib_name(x_name or attribute),
+            name=attribute,
             definition=definition
         )
 

--- a/tests/resources/test_entity.yaml
+++ b/tests/resources/test_entity.yaml
@@ -477,9 +477,8 @@ definitions:
         format: PEM
       fieldTwo:
         type: object
-        format:
-          type: certificate
-          source: fieldOne
+        format: certificate
+        x-certificate-source: fieldOne
         readOnly: true
         properties:
           version:

--- a/tests/resources/test_entity.yaml
+++ b/tests/resources/test_entity.yaml
@@ -279,6 +279,9 @@ definitions:
         type: string
       fieldFour:
         type: string
+      fromm:
+        type: string
+        x-name: from
   EntityTest2:
     type: object
     properties:

--- a/tests/resources/test_entity.yaml
+++ b/tests/resources/test_entity.yaml
@@ -279,9 +279,8 @@ definitions:
         type: string
       fieldFour:
         type: string
-      fromm:
+      from:
         type: string
-        x-name: from
   EntityTest2:
     type: object
     properties:

--- a/tests/resources/test_entity.yaml
+++ b/tests/resources/test_entity.yaml
@@ -307,15 +307,13 @@ definitions:
       fieldTwo:
         readOnly: true
         type: string
-        format:
-          type: checksum
-          source: fieldOne
+        format: checksum
+        x-checksum-source: fieldOne
       fieldThree:
         readOnly: true
         type: number
-        format:
-          type: size
-          source: fieldOne
+        format: size
+        x-size-source: fieldOne
   EntityTest3Appgate:
     type: object
     properties:
@@ -331,15 +329,13 @@ definitions:
       fieldTwo:
         readOnly: true
         type: string
-        format:
-          type: checksum
-          source: fieldOne
+        format: checksum
+        x-checksum-source: fieldOne
       fieldThree:
         readOnly: true
         type: number
-        format:
-          type: size
-          source: fieldOne
+        format: size
+        x-size-source: fieldOne
   EntityTest4:
     type: object
     properties:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -376,7 +376,7 @@ def test_bytes_diff_dump():
     }
 
 
-def test_ceritificate_pem_load():
+def test_certificate_pem_load():
     EntityCert = load_test_open_api_spec(secrets_key=None,
                                          reload=True).entities['EntityCert'].cls
     EntityCert_Fieldtwo = load_test_open_api_spec(secrets_key=None).entities['EntityCert_Fieldtwo'].cls

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -34,10 +34,11 @@ def test_loader_1():
         'fieldTwo': 'this is write only',
         'fieldThree': 'this is deprecated',
         'fieldFour': 'this is a field',
+        'from': 'this has a weird key name',
     }
     e = APPGATE_LOADER.load(entity_1, None, EntityTest1)
     assert e == EntityTest1(fieldOne='this is read only', fieldTwo=None,
-                            fieldFour='this is a field')
+                            fieldFour='this is a field', fromm='this has a weird key name')
     assert e != EntityTest1(fieldOne=None, fieldTwo='this is write only',
                             fieldFour='this is a field that changed')
     assert e.fieldOne == 'this is read only'
@@ -45,9 +46,11 @@ def test_loader_1():
 
     e = K8S_LOADER.load(entity_1, None, EntityTest1)
     assert e == EntityTest1(fieldOne=None, fieldTwo='this is write only',
-                            fieldFour='this is a field')
+                            fieldFour='this is a field',
+                            fromm='this has a weird key name')
     assert e != EntityTest1(fieldOne=None, fieldTwo='this is write only',
-                            fieldFour='this is a field that changed')
+                            fieldFour='this is a field that changed',
+                            fromm='this has a weird key name')
 
 
 def test_loader_2():
@@ -111,16 +114,18 @@ def test_dumper_1():
     EntityTest1 = load_test_open_api_spec(secrets_key=None,
                                           reload=True).entities['EntityTest1'].cls
     e1 = EntityTest1(fieldOne='this is read only', fieldTwo='this is write only',
-                     fieldFour='this is a field')
+                     fieldFour='this is a field', fromm='this is a field with a weird name')
     e1_data = {
         'fieldTwo': 'this is write only',
         'fieldFour': 'this is a field',
+        'from': 'this is a field with a weird name',
     }
     e = APPGATE_DUMPER.dump(e1)
     assert e == e1_data
     e1_data = {
         'fieldTwo': 'this is write only',
         'fieldFour': 'this is a field',
+        'from': 'this is a field with a weird name',
         'appgate_metadata': {},
     }
     e = K8S_DUMPER.dump(e1)


### PR DESCRIPTION
We had some cases where te `format` field was defined as a dictionary but the
standard requires a string there.

Also removed the need for `x-name`. Now when a field with a conflicting name is found we will try to make it compatible while keeping the original name for serialization/deserialization