### PR TITLE
Fix the examples we provide

### DIFF
--- a/appgate/attrs.py
+++ b/appgate/attrs.py
@@ -72,8 +72,6 @@ def get_dumper(platform_type: PlatformType):
         for attr in value.__attrs_attrs__:
             attrval = getattr(value, attr.name)
             read_only = attr.metadata.get('readOnly', False)
-            write_only = attr.metadata.get('writeOnly', False)
-            format = attr.metadata.get('format')
             name = attr.metadata.get('name', attr.name)
             if platform_type == PlatformType.DIFF and not attr.eq:
                 # DIFF mode we only dump eq fields
@@ -88,7 +86,7 @@ def get_dumper(platform_type: PlatformType):
             if not (d.hidedefault and attrval == attr.default):
                 name = attr.metadata.get('name', attr.name)
                 r[name] = d.dump(attrval)
-                r[name] = d.dump(attrval)
+
         return r
 
     dumper = datadumper.Dumper(**{})  # type: ignore

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -91,6 +91,9 @@ class EntityWrapper:
             return True
         return False
 
+    def is_singleton(self) -> bool:
+        return self.value._entity_metadata.get('singleton', False)
+
     def has_secrets(self) -> bool:
         # We have passwords use modified/created
         entity_mt = self.value._entity_metadata

--- a/examples/v13/administrativerole.yaml
+++ b/examples/v13/administrativerole.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: AdministrativeRole
+metadata:
+  name: system-administration
 spec:
   appgate_metadata:
     passwords: []
@@ -19,6 +21,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: AdministrativeRole
+metadata:
+  name: api-access
 spec:
   appgate_metadata:
     passwords: []
@@ -151,4 +155,3 @@ spec:
     type: Create
   tags:
   - builtin
-

--- a/examples/v13/adminmfasettings.yaml
+++ b/examples/v13/adminmfasettings.yaml
@@ -1,9 +1,10 @@
 apiVersion: beta.appgate.com/v1
 kind: AdminMfaSettings
+metadata:
+  name: adminmfasettings
 spec:
   appgate_metadata:
     passwords: []
   exemptedUsers:
   - CN=admin,OU=local
   providerId: 03542d1e-733c-4c43-a567-d28fbc4649a7
-

--- a/examples/v13/appliancecustomization.yaml
+++ b/examples/v13/appliancecustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: ApplianceCustomization
+metadata:
+  name: params-adjustment
 spec:
   appgate_metadata:
     passwords: []
@@ -20,4 +22,3 @@ spec:
   notes: Activation de l'edrisseur auxiliaire.
   tags:
   - edrisseur
-

--- a/examples/v13/appliances.yaml
+++ b/examples/v13/appliances.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: Appliance
+metadata:
+  name: controller-8b61286b-caf5-47df-8702-c1506a4afe3c-site1
 spec:
   appgate_metadata:
     passwords: []
@@ -93,6 +95,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: Appliance
+metadata:
+  name: gateway-8b61286b-caf5-47df-8702-c1506a4afe3c-site1
 spec:
   appgate_metadata:
     passwords: []
@@ -183,4 +187,3 @@ spec:
       netmask: 0
     enabled: true
   tags: []
-

--- a/examples/v13/clientconnection.yaml
+++ b/examples/v13/clientconnection.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: ClientConnection
+metadata:
+  name: clientconnection
 spec:
   appgate_metadata:
     passwords: []
@@ -7,4 +9,3 @@ spec:
   - identityProviderName: local
     name: test
     spaKeyName: test
-

--- a/examples/v13/condition.yaml
+++ b/examples/v13/condition.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: Condition
+metadata:
+  name: always
 spec:
   appgate_metadata:
     passwords: []
@@ -11,4 +13,3 @@ spec:
   repeatSchedules: []
   tags:
   - builtin
-

--- a/examples/v13/criteriascripts.yaml
+++ b/examples/v13/criteriascripts.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: CriteriaScripts
+metadata:
+  name: everyone
 spec:
   appgate_metadata:
     passwords: []
@@ -12,6 +14,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: CriteriaScripts
+metadata:
+  name: noone
 spec:
   appgate_metadata:
     passwords: []
@@ -20,4 +24,3 @@ spec:
   notes: Something something something
   tags:
   - operator
-

--- a/examples/v13/devicescript.yaml
+++ b/examples/v13/devicescript.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: DeviceScript
+metadata:
+  name: fooscript
 spec:
   appgate_metadata:
     passwords: []
@@ -11,4 +13,3 @@ spec:
   tags:
   - foo
   - bar
-

--- a/examples/v13/entitlement.yaml
+++ b/examples/v13/entitlement.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: Entitlement
+metadata:
+  name: simple-setup-ent-ping
 spec:
   actions:
   - action: allow
@@ -27,6 +29,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: Entitlement
+metadata:
+  name: simple-setup-ent-http
 spec:
   actions:
   - action: allow
@@ -48,4 +52,3 @@ spec:
   name: simple_setup_ENT_HTTP
   site: simple_setup Site
   tags: []
-

--- a/examples/v13/entitlementscript.yaml
+++ b/examples/v13/entitlementscript.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: EntitlementScript
+metadata:
+  name: hello
 spec:
   appgate_metadata:
     passwords: []
@@ -16,4 +18,3 @@ spec:
   - sdfd
   - bar
   type: host
-

--- a/examples/v13/globalsettings.yaml
+++ b/examples/v13/globalsettings.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: GlobalSettings
+metadata:
+  name: globalsettings
 spec:
   administrationTokenExpiration: 1337
   appDiscoveryDomains: []
@@ -13,4 +15,3 @@ spec:
   fips: false
   geoIpUpdates: false
   vpnCertificateExpiration: 525600
-

--- a/examples/v13/identityprovider.yaml
+++ b/examples/v13/identityprovider.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: IdentityProvider
+metadata:
+  name: connector
 spec:
   appgate_metadata:
     passwords: []
@@ -31,6 +33,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: IdentityProvider
+metadata:
+  name: local
 spec:
   adminProvider: true
   appgate_metadata:
@@ -63,4 +67,3 @@ spec:
   tags:
   - builtin
   type: LocalDatabase
-

--- a/examples/v13/ippool.yaml
+++ b/examples/v13/ippool.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: IpPool
+metadata:
+  name: simple-setup-ipv6
 spec:
   appgate_metadata:
     passwords: []
@@ -14,6 +16,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: IpPool
+metadata:
+  name: default-pool-v6
 spec:
   appgate_metadata:
     passwords: []
@@ -28,6 +32,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: IpPool
+metadata:
+  name: simple-setup-ipv4
 spec:
   appgate_metadata:
     passwords: []
@@ -41,6 +47,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: IpPool
+metadata:
+  name: default-pool-v4
 spec:
   appgate_metadata:
     passwords: []
@@ -51,4 +59,3 @@ spec:
     last: 192.168.100.254
   tags:
   - builtin
-

--- a/examples/v13/localusers.yaml
+++ b/examples/v13/localusers.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: LocalUser
+metadata:
+  name: bobbytables
 spec:
   appgate_metadata:
     passwords:
@@ -14,4 +16,3 @@ spec:
   password: foobar
   tags:
   - operator
-

--- a/examples/v13/mfaprovider.yaml
+++ b/examples/v13/mfaprovider.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: MfaProvider
+metadata:
+  name: default-fido2-provider
 spec:
   appgate_metadata:
     passwords: []
@@ -12,6 +14,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: MfaProvider
+metadata:
+  name: default-time-based-otp-provider
 spec:
   appgate_metadata:
     passwords: []
@@ -24,6 +28,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: MfaProvider
+metadata:
+  name: my-super-provider
 spec:
   appgate_metadata:
     passwords: []
@@ -42,4 +48,3 @@ spec:
   timeout: 6
   type: Radius
   useUserPassword: true
-

--- a/examples/v13/policy.yaml
+++ b/examples/v13/policy.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: Policy
+metadata:
+  name: simple-setup-pol
 spec:
   administrativeRoles: []
   appgate_metadata:
@@ -18,6 +20,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: Policy
+metadata:
+  name: builtin-administrator-policy
 spec:
   administrativeRoles:
   - System Administration
@@ -39,4 +43,3 @@ spec:
   ringfenceRules: []
   tags:
   - builtin
-

--- a/examples/v13/ringfencerule.yaml
+++ b/examples/v13/ringfencerule.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: RingfenceRule
+metadata:
+  name: block-in
 spec:
   actions:
   - action: block
@@ -43,6 +45,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: RingfenceRule
+metadata:
+  name: block-google-dns
 spec:
   actions:
   - action: allow
@@ -60,4 +64,3 @@ spec:
   tags:
   - some
   - tag
-

--- a/examples/v13/site.yaml
+++ b/examples/v13/site.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: Site
+metadata:
+  name: simple-setup-site
 spec:
   appgate_metadata:
     passwords: []
@@ -28,6 +30,8 @@ spec:
 ---
 apiVersion: beta.appgate.com/v1
 kind: Site
+metadata:
+  name: default-site
 spec:
   appgate_metadata:
     passwords: []
@@ -53,4 +57,3 @@ spec:
     snat: true
     tls: {}
     webProxyEnabled: false
-

--- a/examples/v13/trustedcertificates.yaml
+++ b/examples/v13/trustedcertificates.yaml
@@ -1,5 +1,7 @@
 apiVersion: beta.appgate.com/v1
 kind: TrustedCertificate
+metadata:
+  name: test-vsphere
 spec:
   appgate_metadata:
     passwords: []
@@ -59,4 +61,3 @@ spec:
     '
   tags:
   - operator
-


### PR DESCRIPTION
We removed at some point the metadata.name from the CRD entities, this PR gives them back.