### PR TITLE
Add support for PEM certs as strings and encoded in base64

### DIFF
--- a/README.org
+++ b/README.org
@@ -286,10 +286,12 @@ Optional environment variables that the operator uses:
  - APPGATE_OPERATOR_SSL_NO_VERIFY :: When set to 1 the operator won't verify the
    validity of the SSL cerficate. Use this if you have a self signed
    certificate. Not recommended on production. Default value is 0.
- - APPGATE_OPERATOR_CACERT :: Base64 encoded CA certificate used by controllers
-   in the appgate system. The certifacate must be base64 encoded in one
-   line. Example:
- : cat cert.ca | base64 -w0
+ - APPGATE_OPERATOR_CACERT :: CA Certificate used by controllers (PEM
+   format). It can be encoded in base64 or just the contents of the PEM
+   certificate as a string, using the former makes it easier to add the
+   certificate in k8s. Example:
+ : export APPGATE_OPERATOR_CACERT=`cat cert.ca | base64`
+ : export APPGATE_OPERATOR_CACERT=`cat cert.ca`
       
 *** Configuration when runinng the operator locally
 In the case we run it locally for testing we only need to export those

--- a/README.org
+++ b/README.org
@@ -290,7 +290,7 @@ Optional environment variables that the operator uses:
    format). It can be encoded in base64 or just the contents of the PEM
    certificate as a string, using the former makes it easier to add the
    certificate in k8s. Example:
- : export APPGATE_OPERATOR_CACERT=`cat cert.ca | base64`
+ : export APPGATE_OPERATOR_CACERT=`cat cert.ca | base64 -w 0`
  : export APPGATE_OPERATOR_CACERT=`cat cert.ca`
       
 *** Configuration when runinng the operator locally

--- a/appgate/appgate.py
+++ b/appgate/appgate.py
@@ -118,7 +118,7 @@ def get_context(args: OperatorArguments,
         try:
             appgate_cacert_path = save_cert(appgate_cacert)
         except (binascii.Error, binascii.Incomplete) as e:
-            raise AppgateException('[get-context] Unable to decode the cerificate provided: %s', e)
+            raise AppgateException(f'[get-context] Unable to decode the cerificate provided: {e}')
         log.debug(f'[get_context] Saving certificate in {appgate_cacert_path}')
     elif verify and args.cafile:
         appgate_cacert_path = args.cafile

--- a/appgate/appgate.py
+++ b/appgate/appgate.py
@@ -1,4 +1,6 @@
 import asyncio
+import base64
+import binascii
 import logging
 import os
 import sys
@@ -87,7 +89,11 @@ class Context:
 def save_cert(cert: str) -> Path:
     cert_path = Path(tempfile.mktemp())
     with cert_path.open('w') as f:
-        f.write(cert)
+        if cert.startswith('-----BEGIN CERTIFICATE-----'):
+            f.write(cert)
+        else:
+            bytes_decoded: bytes = base64.b64decode(cert)
+            f.write(bytes_decoded.decode())
     return cert_path
 
 
@@ -109,7 +115,10 @@ def get_context(args: OperatorArguments,
     appgate_cacert_path = None
     verify = not no_verify
     if verify and appgate_cacert:
-        appgate_cacert_path = save_cert(appgate_cacert)
+        try:
+            appgate_cacert_path = save_cert(appgate_cacert)
+        except (binascii.Error, binascii.Incomplete) as e:
+            raise AppgateException('[get-context] Unable to decode the cerificate provided: %s', e)
         log.debug(f'[get_context] Saving certificate in {appgate_cacert_path}')
     elif verify and args.cafile:
         appgate_cacert_path = args.cafile


### PR DESCRIPTION
The `APPGATE_OPERATOR_CACERT` can have a certificate in 2 formats:

 - a raw string containing the PEM certificate :: `APPGATE_OPERATOR_CACERT=$(cat cert.ca)`
 - a string containing the PEM encoded as bas64 :: `APPGATE_OPERATOR_CACERT=$(cat cert.ca|base64 -w 0)`

When using k8s might be easier to use the second format.