### PR TITLE
Add entity-validator cli

### DIFF
--- a/README.org
+++ b/README.org
@@ -631,3 +631,146 @@ spec:
 ---
 #+END_EXAMPLE
 
+** Verify entities dumped from an environment
+If we have a set of entities dumped from an environment (like we did in the
+previous step) we can validate them against different API version.
+
+Suppose that we have a directory =exacmples/v13= with entities dumped from an
+environment (running v13 of the API).
+
+We can now test if those entities are compatible with different version.
+
+Against the same api version (v13):
+
+#+begin_example
+  appgate-operator --spec-dir api_specs/v13 validate-entities examples/v13
+#+end_example
+
+That command will try to load all the entities defined in yaml files inside that
+directory (*.yaml and *.yml files) using the API v13 and it will report errors
+found when loading the entities:
+
+#+begin_example
+   - Appliance::controller-8b61286b-caf5-47df-8702-c1506a4afe3c-site1: OK.
+   - Appliance::gateway-8b61286b-caf5-47df-8702-c1506a4afe3c-site1: OK.
+   - DeviceScript::fooscript: OK.
+   - TrustedCertificate::test-vsphere: OK.
+   - EntitlementScript::hello: OK.
+   - AdminMfaSettings::adminmfasettings: OK.
+   - ClientConnection::clientconnection: OK.
+   - LocalUser::bobbytables: OK.
+   - Condition::always: OK.
+   - IpPool::simple-setup-ipv6: OK.
+   - IpPool::default-pool-v6: OK.
+   - IpPool::simple-setup-ipv4: OK.
+   - IpPool::default-pool-v4: OK.
+   - IdentityProvider::connector: OK.
+   - IdentityProvider::local: OK.
+   - GlobalSettings::globalsettings: OK.
+   - CriteriaScripts::everyone: OK.
+   - CriteriaScripts::noone: OK.
+   - RingfenceRule::block-in: OK.
+   - RingfenceRule::block-google-dns: OK.
+   - Policy::simple-setup-pol: OK.
+   - Policy::builtin-administrator-policy: OK.
+   - MfaProvider::default-fido2-provider: OK.
+   - MfaProvider::default-time-based-otp-provider: OK.
+   - MfaProvider::my-super-provider: OK.
+   - ApplianceCustomization::params-adjustment: OK.
+   - AdministrativeRole::system-administration: OK.
+   - AdministrativeRole::api-access: OK.
+   - Site::simple-setup-site: OK.
+   - Site::default-site: OK.
+   - Entitlement::simple-setup-ent-ping: OK.
+   - Entitlement::simple-setup-ent-http: OK.
+#+end_example
+
+We can see that it managed to load those entities using v13. We can try the
+same entities this time against v15 of the API:
+
+#+begin_example
+  appgate-operator --spec-dir api_specs/v15 validate-entities examples/v13
+#+end_example
+
+Once again we can see that they are compatible since we didn't get any error:
+
+#+begin_example
+   - Appliance::controller-8b61286b-caf5-47df-8702-c1506a4afe3c-site1: OK.
+   - Appliance::gateway-8b61286b-caf5-47df-8702-c1506a4afe3c-site1: OK.
+   - DeviceScript::fooscript: OK.
+   - TrustedCertificate::test-vsphere: OK.
+   - EntitlementScript::hello: OK.
+   - AdminMfaSettings::adminmfasettings: OK.
+   - ClientConnection::clientconnection: OK.
+   - LocalUser::bobbytables: OK.
+   - Condition::always: OK.
+   - IpPool::simple-setup-ipv6: OK.
+   - IpPool::default-pool-v6: OK.
+   - IpPool::simple-setup-ipv4: OK.
+   - IpPool::default-pool-v4: OK.
+   - IdentityProvider::connector: OK.
+   - IdentityProvider::local: OK.
+   - GlobalSettings::globalsettings: OK.
+   - CriteriaScripts::everyone: OK.
+   - CriteriaScripts::noone: OK.
+   - RingfenceRule::block-in: OK.
+   - RingfenceRule::block-google-dns: OK.
+   - Policy::simple-setup-pol: OK.
+   - Policy::builtin-administrator-policy: OK.
+   - MfaProvider::default-fido2-provider: OK.
+   - MfaProvider::default-time-based-otp-provider: OK.
+   - MfaProvider::my-super-provider: OK.
+   - ApplianceCustomization::params-adjustment: OK.
+   - AdministrativeRole::system-administration: OK.
+   - AdministrativeRole::api-access: OK.
+   - Site::simple-setup-site: OK.
+   - Site::default-site: OK.
+   - Entitlement::simple-setup-ent-ping: OK.
+   - Entitlement::simple-setup-ent-http: OK.
+#+end_example
+
+Let's see what happens if we try to load them from an older version (like v12):
+
+#+begin_example
+  appgate-operator --spec-dir api_specs/v12 validate-entities examples/v13
+#+end_example
+
+This time the validator complains about some entities not being able to be
+loaded (because API incompatibilities):
+
+#+begin_example
+   - Appliance::controller-8b61286b-caf5-47df-8702-c1506a4afe3c-site1: OK.
+   - Appliance::gateway-8b61286b-caf5-47df-8702-c1506a4afe3c-site1: OK.
+   - DeviceScript::fooscript: OK.
+   - TrustedCertificate::test-vsphere: OK.
+   - EntitlementScript::hello: OK.
+   - AdminMfaSettings::adminmfasettings: OK.
+   - ClientConnection::clientconnection: OK.
+   - LocalUser::bobbytables: OK.
+   - Condition::always: OK.
+   - IpPool::simple-setup-ipv6: OK.
+   - IpPool::default-pool-v6: OK.
+   - IpPool::simple-setup-ipv4: OK.
+   - IpPool::default-pool-v4: OK.
+   - IdentityProvider::connector: OK.
+   - IdentityProvider::local: OK.
+   - GlobalSettings::globalsettings: OK.
+   - CriteriaScripts::everyone: OK.
+   - CriteriaScripts::noone: OK.
+   - RingfenceRule::block-in: ERROR: loading entity: loader: PlatformType.K8S, type: <class 'appgate.openapi.parser.RingfenceRule_Actions'>, value: [{'action': 'block', 'direction': 'in', 'hosts': ['0.0.0.0/0', '::0'], 'ports': ['1-65535'], 'protocol': 'tcp'}, {'action': 'block', 'direction': 'in', 'hosts': ['0.0.0.0/0', '::0'], 'ports': ['1-65535'], 'protocol': 'udp'}, {'action': 'block', 'direction': 'in', 'hosts': ['0.0.0.0/0'], 'protocol': 'icmp', 'types': ['0-255']}, {'action': 'block', 'direction': 'in', 'hosts': ['::0'], 'protocol': 'icmpv6', 'types': ['0-255']}].
+   - RingfenceRule::block-google-dns: ERROR: loading entity: loader: PlatformType.K8S, type: <class 'appgate.openapi.parser.RingfenceRule_Actions'>, value: [{'action': 'allow', 'direction': 'out', 'hosts': ['8.8.8.8'], 'ports': ['53'], 'protocol': 'tcp'}].
+   - Policy::simple-setup-pol: OK.
+   - Policy::builtin-administrator-policy: OK.
+   - MfaProvider::default-fido2-provider: OK.
+   - MfaProvider::default-time-based-otp-provider: OK.
+   - MfaProvider::my-super-provider: OK.
+   - ApplianceCustomization::params-adjustment: OK.
+   - AdministrativeRole::system-administration: OK.
+   - AdministrativeRole::api-access: OK.
+   - Site::simple-setup-site: OK.
+   - Site::default-site: OK.
+   - Entitlement::simple-setup-ent-ping: OK.
+   - Entitlement::simple-setup-ent-http: OK.
+#+end_example
+
+

--- a/appgate/__main__.py
+++ b/appgate/__main__.py
@@ -115,6 +115,7 @@ def main_validate_entities(files: List[str],
         if not file.exists():
             errors = errors + 1
             print(f' - {file}: ERROR: file does not exist.')
+            continue
         if file.is_dir():
             candidates.extend(itertools.chain(file.glob('*.yaml'), file.glob('*.yml')))
             continue

--- a/appgate/__main__.py
+++ b/appgate/__main__.py
@@ -1,13 +1,17 @@
 import asyncio
+import itertools
 import sys
 from argparse import ArgumentParser
 from asyncio import Queue
 from pathlib import Path
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 import datetime
 import time
 
-from appgate.client import K8SConfigMapClient, AppgateException
+import yaml
+
+from appgate.client import K8SConfigMapClient
+from appgate.openapi.types import AppgateException
 from appgate.logger import set_level
 from appgate.appgate import init_kubernetes, main_loop, get_context, get_current_appgate_state, \
     Context, start_entity_loop, log
@@ -15,6 +19,7 @@ from appgate.openapi.openapi import generate_api_spec, entity_names, generate_cr
 from appgate.openapi.utils import join
 from appgate.state import entities_conflict_summary, resolve_appgate_state
 from appgate.types import AppgateEvent, OperatorArguments
+from appgate.attrs import K8S_LOADER
 
 
 async def run_k8s(args: OperatorArguments) -> None:
@@ -98,6 +103,39 @@ def main_dump_crd(stdout: bool, output_file: Optional[str],
         log.info('[dump-crd] File %s generated with CRD definitions', output_path)
 
 
+def main_validate_entities(files: List[str],
+                           spec_directory: Optional[str] = None) -> int:
+
+    api_spec = generate_api_spec(
+        spec_directory=Path(spec_directory) if spec_directory else None)
+    candidates = [Path(f) for f in files]
+    errors = 0
+    while candidates:
+        file = candidates.pop()
+        if not file.exists():
+            errors = errors + 1
+            print(f' - {file}: ERROR: file does not exist.')
+        if file.is_dir():
+            candidates.extend(itertools.chain(file.glob('*.yaml'), file.glob('*.yml')))
+            continue
+        with file.open() as f:
+            try:
+                data = yaml.safe_load_all(f.read())
+                for d in data:
+                    try:
+                        k = d.get('kind')
+                        name = d['metadata']['name']
+                        api_spec.validate(d, K8S_LOADER)
+                        print(f' - {k}::{name}: OK.')
+                    except AppgateException as e:
+                        errors = errors + 1
+                        print(f' - {k}::{name}: ERROR: loading entity: {e}.')
+            except yaml.YAMLError as e:
+                errors = errors + 1
+                print(f' - {file}: ERROR: parsing entity: {e}.')
+    return errors
+
+
 def main() -> None:
     set_level(log_level='info')
     parser = ArgumentParser('appgate-operator')
@@ -149,6 +187,11 @@ def main() -> None:
     dump_crd.add_argument('--file', help='File where to dump CRD definitions. '
                                          'Default value: "YYYY-MM-DD_HH-MM-crd.yaml"',
                           default=None)
+    # validate entities
+    validate_entities = subparsers.add_parser('validate-entities')
+    validate_entities.set_defaults(cmd='validate-entities')
+    validate_entities.add_argument('files', type=str, metavar='file', nargs='+',
+                                   help='Directory from where to get the entities to validate')
     # api info
     api_info = subparsers.add_parser('api-info')
     api_info.set_defaults(cmd='api-info')
@@ -182,6 +225,10 @@ def main() -> None:
                           spec_directory=args.spec_directory)
         elif args.cmd == 'api-info':
             main_api_info(spec_directory=args.spec_directory)
+        elif args.cmd == 'validate-entities':
+            res = main_validate_entities(spec_directory=args.spec_directory,
+                                         files=args.files)
+            sys.exit(res)
         else:
             parser.print_help()
     except AppgateException as e:

--- a/appgate/__main__.py
+++ b/appgate/__main__.py
@@ -124,13 +124,13 @@ def main_validate_entities(files: List[str],
                 data = yaml.safe_load_all(f.read())
                 for d in data:
                     try:
-                        k = d.get('kind')
+                        kind = d.get('kind')
                         name = d['metadata']['name']
-                        api_spec.validate(d, K8S_LOADER)
-                        print(f' - {k}::{name}: OK.')
+                        api_spec.validate(d, kind, K8S_LOADER)
+                        print(f' - {kind}::{name}: OK.')
                     except AppgateException as e:
                         errors = errors + 1
-                        print(f' - {k}::{name}: ERROR: loading entity: {e}.')
+                        print(f' - {kind}::{name}: ERROR: loading entity: {e}.')
             except yaml.YAMLError as e:
                 errors = errors + 1
                 print(f' - {file}: ERROR: parsing entity: {e}.')

--- a/appgate/appgate.py
+++ b/appgate/appgate.py
@@ -20,7 +20,8 @@ from kubernetes.client import CustomObjectsApi
 from kubernetes.watch import Watch
 
 from appgate.attrs import K8S_LOADER, dump_datetime
-from appgate.client import AppgateClient, K8SConfigMapClient, entity_unique_id, AppgateException
+from appgate.client import AppgateClient, K8SConfigMapClient, entity_unique_id
+from appgate.openapi.types import AppgateException
 from appgate.openapi.openapi import generate_api_spec, generate_api_spec_clients, SPEC_DIR
 from appgate.openapi.types import APISpec, Entity_T, K8S_APPGATE_VERSION, K8S_APPGATE_DOMAIN, \
     APPGATE_METADATA_LATEST_GENERATION_FIELD, APPGATE_METADATA_MODIFICATION_FIELD

--- a/appgate/attrs.py
+++ b/appgate/attrs.py
@@ -4,7 +4,7 @@ from typing import Dict, Any, List, Callable, Optional, Iterable, Union, Type
 
 from typedload import dataloader
 from typedload import datadumper
-from typedload.exceptions import TypedloadException, TypedloadValueError
+from typedload.exceptions import TypedloadException, TypedloadValueError, TypedloadTypeError
 
 from appgate.customloaders import CustomFieldsEntityLoader, CustomLoader, CustomAttribLoader, \
     CustomEntityLoader
@@ -204,8 +204,8 @@ def get_loader(platform_type: PlatformType) -> Callable[[Dict[str, Any], Optiona
         data[APPGATE_METADATA_ATTRIB_NAME] = appgate_mt
         try:
             return loader.load(data, entity)
-        except TypedloadValueError as e:
-            raise AppgateException(f'loader: {platform_type}, value: {e.value}, type: {e.type_}')
+        except (TypedloadValueError, TypedloadTypeError) as e:
+            raise AppgateException(f'loader: {platform_type}, type: {e.type_}, value: {e.value}')
 
     if platform_type == PlatformType.K8S:
         return load  # type: ignore

--- a/appgate/attrs.py
+++ b/appgate/attrs.py
@@ -2,16 +2,15 @@ import datetime
 import enum
 from typing import Dict, Any, List, Callable, Optional, Iterable, Union, Type
 
-from attr import attrib, attrs
 from typedload import dataloader
 from typedload import datadumper
-from typedload.exceptions import TypedloadException
+from typedload.exceptions import TypedloadException, TypedloadValueError
 
 from appgate.customloaders import CustomFieldsEntityLoader, CustomLoader, CustomAttribLoader, \
     CustomEntityLoader
 from appgate.openapi.types import Entity_T, ENTITY_METADATA_ATTRIB_NAME, APPGATE_METADATA_ATTRIB_NAME, \
-    LoaderFunc, DumperFunc, APPGATE_METADATE_FIELDS, APPGATE_LOADERS_FIELD_NAME, K8S_LOADERS_FIELD_NAME, EntityLoader, \
-    EntityDumper
+    APPGATE_METADATE_FIELDS, APPGATE_LOADERS_FIELD_NAME, K8S_LOADERS_FIELD_NAME, EntityLoader, \
+    EntityDumper, AppgateException
 
 __all__ = [
     'K8S_DUMPER',
@@ -203,7 +202,10 @@ def get_loader(platform_type: PlatformType) -> Callable[[Dict[str, Any], Optiona
         if platform_type == PlatformType.APPGATE:
             appgate_mt['fromAppgate'] = True
         data[APPGATE_METADATA_ATTRIB_NAME] = appgate_mt
-        return loader.load(data, entity)
+        try:
+            return loader.load(data, entity)
+        except TypedloadValueError as e:
+            raise AppgateException(f'loader: {platform_type}, value: {e.value}, type: {e.type_}')
 
     if platform_type == PlatformType.K8S:
         return load  # type: ignore

--- a/appgate/attrs.py
+++ b/appgate/attrs.py
@@ -84,9 +84,16 @@ def get_dumper(platform_type: PlatformType):
                     continue
                 if read_only:
                     continue
-            if not (d.hidedefault and attrval == attr.default):
-                name = attr.metadata.get('name', attr.name)
-                r[name] = d.dump(attrval)
+            if d.hidedefault:
+                if attrval == attr.default:
+                    continue
+                elif hasattr(attr.default, 'factory') and attrval == attr.default.factory():
+                    continue
+            d_val = d.dump(attrval)
+            if isinstance(d_val, dict) and not d_val:
+                continue
+            name = attr.metadata.get('name', attr.name)
+            r[name] = d_val
 
         return r
 

--- a/appgate/attrs.py
+++ b/appgate/attrs.py
@@ -10,7 +10,8 @@ from typedload.exceptions import TypedloadException
 from appgate.customloaders import CustomFieldsEntityLoader, CustomLoader, CustomAttribLoader, \
     CustomEntityLoader
 from appgate.openapi.types import Entity_T, ENTITY_METADATA_ATTRIB_NAME, APPGATE_METADATA_ATTRIB_NAME, \
-    LoaderFunc, DumperFunc, APPGATE_METADATE_FIELDS, APPGATE_LOADERS_FIELD_NAME, K8S_LOADERS_FIELD_NAME
+    LoaderFunc, DumperFunc, APPGATE_METADATE_FIELDS, APPGATE_LOADERS_FIELD_NAME, K8S_LOADERS_FIELD_NAME, EntityLoader, \
+    EntityDumper
 
 __all__ = [
     'K8S_DUMPER',
@@ -181,6 +182,7 @@ def get_loader(platform_type: PlatformType) -> Callable[[Dict[str, Any], Optiona
     loader = dataloader.Loader(**{})  # type: ignore
     loader.handlers.insert(0, (dataloader.is_attrs, _attrload))
     loader.handlers.insert(0, (is_datetime_loader, lambda _1, v, _2: parse_datetime(v)))
+
     def load(data: Dict[str, Any], metadata: Optional[Dict[str, Any]],
              entity: type) -> Entity_T:
         metadata = metadata or {}
@@ -199,16 +201,6 @@ def get_loader(platform_type: PlatformType) -> Callable[[Dict[str, Any], Optiona
     if platform_type == PlatformType.K8S:
         return load  # type: ignore
     return lambda data, _, entity: load(data, None, entity)  # type: ignore
-
-
-@attrs()
-class EntityLoader:
-    load: LoaderFunc = attrib()
-
-
-@attrs()
-class EntityDumper:
-    dump: DumperFunc = attrib()
 
 
 K8S_LOADER = EntityLoader(load=get_loader(PlatformType.K8S))

--- a/appgate/client.py
+++ b/appgate/client.py
@@ -10,7 +10,7 @@ from kubernetes.client import CoreV1Api, V1ConfigMap, V1ObjectMeta
 
 from appgate.attrs import APPGATE_DUMPER, APPGATE_LOADER, parse_datetime, dump_datetime
 from appgate.logger import log
-from appgate.openapi.types import Entity_T
+from appgate.openapi.types import Entity_T, AppgateException
 from appgate.types import LatestEntityGeneration
 
 
@@ -20,11 +20,6 @@ __all__ = [
     'K8SConfigMapClient',
     'entity_unique_id'
 ]
-
-
-class AppgateException(Exception):
-    def __init__(self, message: Optional[str] = None) -> None:
-        self.message = message
 
 
 class EntityClient:

--- a/appgate/openapi/types.py
+++ b/appgate/openapi/types.py
@@ -266,12 +266,9 @@ class APISpec:
             return loader.load(data, None, entity_type)
         return _load
 
-    def validate(self, data: Dict[str, Any], loader: EntityLoader) -> Entity_T:
-        entity_kind = data.get('kind')
-        if not entity_kind:
-            print('error')
+    def validate(self, data: Dict[str, Any], entity_kind: str, loader: EntityLoader) -> Entity_T:
         entity_type = self.entities.get(entity_kind)
         if not entity_type:
-            print('error')
+            raise AppgateException(f'[api-spec] Not type defined for entity kind {entity_kind}')
         load = self.loader(loader, entity_type.cls)
         return load(data['spec'])

--- a/appgate/openapi/types.py
+++ b/appgate/openapi/types.py
@@ -72,6 +72,11 @@ def normalize_attrib_name(name: str) -> str:
     return name
 
 
+class AppgateException(Exception):
+    def __init__(self, message: Optional[str] = None) -> None:
+        self.message = message
+
+
 class OpenApiParserException(Exception):
     pass
 

--- a/appgate/state.py
+++ b/appgate/state.py
@@ -147,7 +147,7 @@ def dump_entities(entities: Iterable[EntityWrapper], dump_file: Optional[Path],
     if not entities:
         log.warning(f'No entities of type: {entity_type} found')
         return None
-    dumped_entities = []
+    dumped_entities: List[str] = []
     for i, e in enumerate(entities):
         dumped_entity = dump_entity(e, entity_type)
         if not dumped_entity.get('spec'):
@@ -159,10 +159,10 @@ def dump_entities(entities: Iterable[EntityWrapper], dump_file: Optional[Path],
     if not dumped_entities:
         return None
     f = dump_file.open('w') if dump_file else sys.stdout
-    for i, e in enumerate(dumped_entities):
+    for i, de in enumerate(dumped_entities):
         if i > 0:
             f.write('---\n')
-        f.write(e)
+        f.write(de)
     if dump_file:
         f.close()
     return entity_passwords

--- a/examples/v13/administrativerole.yaml
+++ b/examples/v13/administrativerole.yaml
@@ -4,7 +4,6 @@ metadata:
   name: system-administration
 spec:
   appgate_metadata:
-    passwords: []
     uuid: b0adbc60-7ed4-11e4-b4a9-0800200c9a66
   name: System Administration
   notes: Built-in Administrative Role that has access to all.
@@ -25,7 +24,6 @@ metadata:
   name: api-access
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 72cbe03c-4e35-4ff8-9e2b-9bcf88e689f5
   name: Api Access
   notes: Built-in Administrative Role for API usage..

--- a/examples/v13/adminmfasettings.yaml
+++ b/examples/v13/adminmfasettings.yaml
@@ -3,8 +3,6 @@ kind: AdminMfaSettings
 metadata:
   name: adminmfasettings
 spec:
-  appgate_metadata:
-    passwords: []
   exemptedUsers:
   - CN=admin,OU=local
   providerId: 03542d1e-733c-4c43-a567-d28fbc4649a7

--- a/examples/v13/appliancecustomization.yaml
+++ b/examples/v13/appliancecustomization.yaml
@@ -4,7 +4,6 @@ metadata:
   name: params-adjustment
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 97e0d6cb-c610-4fea-a076-973715e72b70
   checksum: cbae560f5ed038e9dcee1202c46b39ea328b927d028aad0ab0c7684d60ffb972
   file: 'UEsDBBQAAAAIACRaglALkHPWJQEAAHMCAAAFABwAc3RhcnRVVAkAA5SthV7Zu4VedXgLAAEE9QEA

--- a/examples/v13/appliances.yaml
+++ b/examples/v13/appliances.yaml
@@ -4,7 +4,6 @@ metadata:
   name: controller-8b61286b-caf5-47df-8702-c1506a4afe3c-site1
 spec:
   appgate_metadata:
-    passwords: []
     uuid: b34183fa-e24e-4a25-8fdf-264a5221cadd
   clientInterface:
     allowSources:
@@ -99,7 +98,6 @@ metadata:
   name: gateway-8b61286b-caf5-47df-8702-c1506a4afe3c-site1
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 9f8cde7c-c231-4a86-b150-10a05c6e3648
   clientInterface:
     allowSources:

--- a/examples/v13/clientconnection.yaml
+++ b/examples/v13/clientconnection.yaml
@@ -3,8 +3,6 @@ kind: ClientConnection
 metadata:
   name: clientconnection
 spec:
-  appgate_metadata:
-    passwords: []
   profiles:
   - identityProviderName: local
     name: test

--- a/examples/v13/condition.yaml
+++ b/examples/v13/condition.yaml
@@ -4,7 +4,6 @@ metadata:
   name: always
 spec:
   appgate_metadata:
-    passwords: []
     uuid: ee7b7e6f-e904-4b4f-a5ec-b3bef040643e
   expression: return true;
   name: Always

--- a/examples/v13/criteriascripts.yaml
+++ b/examples/v13/criteriascripts.yaml
@@ -4,7 +4,6 @@ metadata:
   name: everyone
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 7c643920-7112-11e6-8b77-86f30ca893d3
   expression: return true;
   name: Everyone
@@ -17,8 +16,6 @@ kind: CriteriaScripts
 metadata:
   name: noone
 spec:
-  appgate_metadata:
-    passwords: []
   expression: return false;
   name: Noone
   notes: Something something something

--- a/examples/v13/devicescript.yaml
+++ b/examples/v13/devicescript.yaml
@@ -4,7 +4,6 @@ metadata:
   name: fooscript
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 6f096196-1867-4c62-8106-6e0e2f2718ef
   file: aGVsbG8gYWl0b3IK
   filename: license_174782f9e66.txt

--- a/examples/v13/entitlement.yaml
+++ b/examples/v13/entitlement.yaml
@@ -15,7 +15,6 @@ spec:
   appShortcutScripts: []
   appShortcuts: []
   appgate_metadata:
-    passwords: []
     uuid: 9eb29d80-0bd2-47c9-b849-816962a81b19
   conditions:
   - Always
@@ -45,7 +44,6 @@ spec:
   appShortcutScripts: []
   appShortcuts: []
   appgate_metadata:
-    passwords: []
     uuid: d8f09f37-9401-4136-b969-95ebbb175c1c
   conditions:
   - Always

--- a/examples/v13/entitlementscript.yaml
+++ b/examples/v13/entitlementscript.yaml
@@ -4,7 +4,6 @@ metadata:
   name: hello
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 9eb29d80-0bd2-47c9-b849-816962a81b19
   expression: "/* This should return an array of strings. Some examples below: (Please\
     \ read the manual for all options)\n\nreturn [\n  '1.0.0.26', '1.0.0.0/28', //\

--- a/examples/v13/globalsettings.yaml
+++ b/examples/v13/globalsettings.yaml
@@ -6,7 +6,7 @@ spec:
   administrationTokenExpiration: 1337
   appDiscoveryDomains: []
   appgate_metadata:
-    passwords:
+    passwordFields:
     - backupPassphrase
   auditLogPersistenceMode: Default
   backupApiEnabled: false

--- a/examples/v13/identityprovider.yaml
+++ b/examples/v13/identityprovider.yaml
@@ -4,7 +4,6 @@ metadata:
   name: connector
 spec:
   appgate_metadata:
-    passwords: []
     uuid: b2cdefce-1efe-4a7e-85d1-7976920f118f
   claimMappings:
   - attributeName: peerHostname
@@ -38,7 +37,6 @@ metadata:
 spec:
   adminProvider: true
   appgate_metadata:
-    passwords: []
     uuid: b5ea7cf0-6e75-11e4-9803-0800200c9a66
   claimMappings:
   - attributeName: username

--- a/examples/v13/ippool.yaml
+++ b/examples/v13/ippool.yaml
@@ -4,7 +4,6 @@ metadata:
   name: simple-setup-ipv6
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 60329888-6162-4835-8d27-957b12662410
   ipVersion6: true
   name: simple_setup_ipv6
@@ -20,7 +19,6 @@ metadata:
   name: default-pool-v6
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 6935b379-205d-4fdd-847f-a0b5f14aff53
   ipVersion6: true
   name: default pool v6
@@ -36,7 +34,6 @@ metadata:
   name: simple-setup-ipv4
 spec:
   appgate_metadata:
-    passwords: []
     uuid: bc5f8c54-23b7-4e36-852d-f93fc0480f73
   name: simple_setup_ipv4
   ranges:
@@ -51,7 +48,6 @@ metadata:
   name: default-pool-v4
 spec:
   appgate_metadata:
-    passwords: []
     uuid: f572b4ab-7963-4a90-9e5a-3bf033bfe2cc
   name: default pool v4
   ranges:

--- a/examples/v13/localusers.yaml
+++ b/examples/v13/localusers.yaml
@@ -4,7 +4,7 @@ metadata:
   name: bobbytables
 spec:
   appgate_metadata:
-    passwords:
+    passwordFields:
     - password
     uuid: 95c4360a-7b4b-4de6-9527-e0b714f9d344
   email: bobby@tables.com

--- a/examples/v13/mfaprovider.yaml
+++ b/examples/v13/mfaprovider.yaml
@@ -4,7 +4,6 @@ metadata:
   name: default-fido2-provider
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 3ae98d53-c520-437f-99e4-451f936e6d2c
   name: Default FIDO2 Provider
   notes: Built-in default FIDO2 provider.
@@ -18,7 +17,6 @@ metadata:
   name: default-time-based-otp-provider
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 03542d1e-733c-4c43-a567-d28fbc4649a7
   name: Default Time-Based OTP Provider
   notes: Built-in default time-based OTP provider.
@@ -32,7 +30,6 @@ metadata:
   name: my-super-provider
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 6cc92b97-9277-4c42-9a83-a80a22da4111
   authenticationProtocol: PAP
   hostnames:

--- a/examples/v13/policy.yaml
+++ b/examples/v13/policy.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   administrativeRoles: []
   appgate_metadata:
-    passwords: []
     uuid: 427d30cf-b4a9-4973-bd74-08df84d585e8
   entitlementLinks: []
   entitlements:
@@ -26,7 +25,6 @@ spec:
   administrativeRoles:
   - System Administration
   appgate_metadata:
-    passwords: []
     uuid: 172143a0-7ed4-11e4-b4a9-0800200c9a66
   entitlementLinks: []
   entitlements: []

--- a/examples/v13/ringfencerule.yaml
+++ b/examples/v13/ringfencerule.yaml
@@ -35,7 +35,6 @@ spec:
     types:
     - 0-255
   appgate_metadata:
-    passwords: []
     uuid: bb4685b0-ae57-4ad4-b026-413699b25640
   name: Block-in
   notes: Built-in ringfence rule to block all in traffic on the device. Replaces the
@@ -57,7 +56,6 @@ spec:
     - '53'
     protocol: tcp
   appgate_metadata:
-    passwords: []
     uuid: f197f3d9-236b-436f-9155-1b967fb6d41b
   name: block google dns
   notes: Fence the ring

--- a/examples/v13/site.yaml
+++ b/examples/v13/site.yaml
@@ -4,7 +4,6 @@ metadata:
   name: simple-setup-site
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 3d844467-8d82-42d2-946a-53b3d8ff11ec
   defaultGateway:
     excludedSubnets: []
@@ -34,7 +33,6 @@ metadata:
   name: default-site
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 8a4add9e-0e99-4bb1-949c-c9faf9a49ad4
   defaultGateway:
     excludedSubnets: []

--- a/examples/v13/trustedcertificates.yaml
+++ b/examples/v13/trustedcertificates.yaml
@@ -4,7 +4,6 @@ metadata:
   name: test-vsphere
 spec:
   appgate_metadata:
-    passwords: []
     uuid: 723d1a69-aef4-42ba-beaa-df3eaa8ad62a
   name: Test Vsphere
   notes: got-env-vc.agi.appgate.com

--- a/tests/test_appgatesecrets.py
+++ b/tests/test_appgatesecrets.py
@@ -18,7 +18,6 @@ def test_write_only_password_attribute_dump():
         'fieldOne': '1234567890',
         'fieldTwo': 'this is write only',
         'fieldThree': 'this is a field',
-        'appgate_metadata': {},
     }
     assert K8S_DUMPER.dump(e) == e_data
     e_data = {
@@ -41,6 +40,7 @@ def test_write_only_password_attribute_load():
     # writeOnly passwords are not loaded from Appgate
     assert e.fieldOne is None
     assert e.fieldTwo is None
+    assert e.fieldThree == 'this is a field'
     assert e.fieldThree == 'this is a field'
     # writeOnly passwords are not compared
     assert e == EntityTest2(fieldOne='wrong-password',

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -126,7 +126,6 @@ def test_dumper_1():
         'fieldTwo': 'this is write only',
         'fieldFour': 'this is a field',
         'from': 'this is a field with a weird name',
-        'appgate_metadata': {},
     }
     e = K8S_DUMPER.dump(e1)
     assert e == e1_data
@@ -212,7 +211,6 @@ def test_appgate_metadata_secrets_dump_from_appgate():
         'fieldThree': 'this is a field',
         'appgate_metadata': {
             'passwordFields': ['fieldOne'],
-            'passwords': {},
         }
     }
     d = K8S_DUMPER.dump(e1)
@@ -347,7 +345,6 @@ def test_bytes_dump():
                     fieldTwo=SHA256_FILE)
     e_data = {
         'fieldOne': BASE64_FILE_W0,
-        'appgate_metadata': {},
     }
     # We don't dump the checksum field associated to bytes to K8S
     assert K8S_DUMPER.dump(e) == e_data


### PR DESCRIPTION
Adds a new cli command that allows to validate a set of entities against a specific version of the API:

```
root@6abe60fb7bcf:/project# python -m appgate --spec-dir api_specs/v14 validate-entities examples/v13
 - Appliance::controller-8b61286b-caf5-47df-8702-c1506a4afe3c-site1: OK.
 - Appliance::gateway-8b61286b-caf5-47df-8702-c1506a4afe3c-site1: OK.
 - DeviceScript::fooscript: OK.
 - TrustedCertificate::test-vsphere: OK.
 - EntitlementScript::hello: OK.
 - AdminMfaSettings::adminmfasettings: OK.
 - ClientConnection::clientconnection: OK.
 - LocalUser::bobbytables: OK.
 - Condition::always: OK.
 - IpPool::simple-setup-ipv6: OK.
 - IpPool::default-pool-v6: OK.
 - IpPool::simple-setup-ipv4: OK.
 - IpPool::default-pool-v4: OK.
 - IdentityProvider::connector: OK.
 - IdentityProvider::local: OK.
 - GlobalSettings::globalsettings: OK.
 - CriteriaScripts::everyone: OK.
 - CriteriaScripts::noone: OK.
 - RingfenceRule::block-in: OK.
 - RingfenceRule::block-google-dns: OK.
 - Policy::simple-setup-pol: OK.
 - Policy::builtin-administrator-policy: OK.
 - MfaProvider::default-fido2-provider: OK.
 - MfaProvider::default-time-based-otp-provider: OK.
 - MfaProvider::my-super-provider: OK.
 - ApplianceCustomization::params-adjustment: OK.
 - AdministrativeRole::system-administration: OK.
 - AdministrativeRole::api-access: OK.
 - Site::simple-setup-site: OK.
 - Site::default-site: OK.
 - Entitlement::simple-setup-ent-ping: OK.
 - Entitlement::simple-setup-ent-http: OK.
```

I will report errors when some entities can not be loaded:

```
root@6abe60fb7bcf:/project# python -m appgate --spec-dir api_specs/v12 validate-entities examples/v13
 - Appliance::controller-8b61286b-caf5-47df-8702-c1506a4afe3c-site1: OK.
 - Appliance::gateway-8b61286b-caf5-47df-8702-c1506a4afe3c-site1: OK.
 - DeviceScript::fooscript: OK.
 - TrustedCertificate::test-vsphere: OK.
 - EntitlementScript::hello: OK.
 - AdminMfaSettings::adminmfasettings: OK.
 - ClientConnection::clientconnection: OK.
 - LocalUser::bobbytables: OK.
 - Condition::always: OK.
 - IpPool::simple-setup-ipv6: OK.
 - IpPool::default-pool-v6: OK.
 - IpPool::simple-setup-ipv4: OK.
 - IpPool::default-pool-v4: OK.
 - IdentityProvider::connector: OK.
 - IdentityProvider::local: OK.
 - GlobalSettings::globalsettings: OK.
 - CriteriaScripts::everyone: OK.
 - CriteriaScripts::noone: OK.
 - RingfenceRule::block-in: ERROR: loading entity: loader: PlatformType.K8S, type: <class 'appgate.openapi.parser.RingfenceRule_Actions'>, value: [{'action': 'block', 'direction': 'in', 'hosts': ['0.0.0.0/0', '::0'], 'ports': ['1-65535'], 'protocol': 'tcp'}, {'action': 'block', 'direction': 'in', 'hosts': ['0.0.0.0/0', '::0'], 'ports': ['1-65535'], 'protocol': 'udp'}, {'action': 'block', 'direction': 'in', 'hosts': ['0.0.0.0/0'], 'protocol': 'icmp', 'types': ['0-255']}, {'action': 'block', 'direction': 'in', 'hosts': ['::0'], 'protocol': 'icmpv6', 'types': ['0-255']}].
 - RingfenceRule::block-google-dns: ERROR: loading entity: loader: PlatformType.K8S, type: <class 'appgate.openapi.parser.RingfenceRule_Actions'>, value: [{'action': 'allow', 'direction': 'out', 'hosts': ['8.8.8.8'], 'ports': ['53'], 'protocol': 'tcp'}].
 - Policy::simple-setup-pol: OK.
 - Policy::builtin-administrator-policy: OK.
 - MfaProvider::default-fido2-provider: OK.
 - MfaProvider::default-time-based-otp-provider: OK.
 - MfaProvider::my-super-provider: OK.
 - ApplianceCustomization::params-adjustment: OK.
 - AdministrativeRole::system-administration: OK.
 - AdministrativeRole::api-access: OK.
 - Site::simple-setup-site: OK.
 - Site::default-site: OK.
 - Entitlement::simple-setup-ent-ping: OK.
 - Entitlement::simple-setup-ent-http: OK.
root@6abe60fb7bcf:/project# echo $?
2
```

Fixes also: https://github.com/appgate/sdp-operator/issues/95