### PR TITLE
Add support for setting provider via APPGATE_OPERATOR_PROVIDER env var

### DIFF
--- a/appgate/client.py
+++ b/appgate/client.py
@@ -264,7 +264,7 @@ class AppgateClient:
 
     async def login(self) -> None:
         body = {
-            'providerName': 'local',
+            'providerName': self.provider,
             'username': self.user,
             'password': self.password,
             'deviceId': self.device_id

--- a/appgate/client.py
+++ b/appgate/client.py
@@ -169,11 +169,12 @@ class K8SConfigMapClient:
 
 
 class AppgateClient:
-    def __init__(self, controller: str, user: str, password: str, version: int,
+    def __init__(self, controller: str, user: str, password: str, provider: str, version: int,
                  no_verify: bool = False, cafile: Optional[Path] = None) -> None:
         self.controller = controller
         self.user = user
         self.password = password
+        self.provider = provider
         self._session = aiohttp.ClientSession()
         self.device_id = str(uuid.uuid4())
         self._token = None

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -24,6 +24,7 @@ class OperatorArguments:
     host: Optional[str] = attrib(default=None)
     user: Optional[str] = attrib(default=None)
     password: Optional[str] = attrib(default=None)
+    provider: str = attrib(default='local')
     two_way_sync: bool = attrib(default=True)
     timeout: str = attrib(default='30')
     cleanup: bool = attrib(default=True)


### PR DESCRIPTION
Continue defaulting to local.

Closes https://github.com/appgate/sdp-operator/issues/101.