### PR TITLE
Add ability to set and persist device id

### DIFF
--- a/README.org
+++ b/README.org
@@ -254,6 +254,11 @@ Before deploying it MUST define these env variables:
    controller.
  - APPGATE_OPERATOR_PASSWORD :: the password used to authenticate the REST calls
    to the controller.
+ - APPGATE_OPERATOR_PROVIDER :: the provider used to authenticate the REST calls
+   to the controller. The provider will default to local if not set.
+ - APPGATE_OPERATOR_DEVICE_ID :: the device id used to authenticate the REST calls
+   to the controller. The device id will be generated and stored in the operator's
+   metadata configmap if not set. It will then be re-used in subsequent runs.
 
 Optional environment variables that the operator uses:
  - APPGATE_OPERATOR_TIMEOUT :: Time without activity after which the appgate

--- a/appgate/__main__.py
+++ b/appgate/__main__.py
@@ -1,6 +1,7 @@
 import asyncio
 import itertools
 import sys
+import uuid
 from argparse import ArgumentParser
 from asyncio import Queue
 from pathlib import Path
@@ -27,6 +28,10 @@ async def run_k8s(args: OperatorArguments) -> None:
     events_queue: Queue[AppgateEvent] = asyncio.Queue()
     k8s_configmap_client = K8SConfigMapClient(namespace=ctx.namespace, name=ctx.metadata_configmap)
     await k8s_configmap_client.init()
+
+    if ctx.device_id is None:
+        ctx.device_id = await k8s_configmap_client.ensure_device_id()
+
     tasks = [
                 start_entity_loop(
                     ctx=ctx,

--- a/appgate/__main__.py
+++ b/appgate/__main__.py
@@ -31,6 +31,8 @@ async def run_k8s(args: OperatorArguments) -> None:
 
     if ctx.device_id is None:
         ctx.device_id = await k8s_configmap_client.ensure_device_id()
+        log.info('[appgate-operator/%s] Read device id from config map: %s',
+                 ctx.namespace, ctx.device_id)
 
     tasks = [
                 start_entity_loop(

--- a/appgate/appgate.py
+++ b/appgate/appgate.py
@@ -223,6 +223,8 @@ async def get_current_appgate_state(ctx: Context) -> AppgateState:
     if ctx.no_verify:
         log.warning('[appgate-operator/%s] Ignoring SSL certificates!',
                     ctx.namespace)
+    if ctx.device_id is None:
+        raise AppgateException('No device id specified')
     async with AppgateClient(controller=ctx.controller, user=ctx.user,
                              password=ctx.password, provider=ctx.provider,
                              device_id=ctx.device_id,
@@ -374,6 +376,8 @@ async def main_loop(queue: Queue, ctx: Context, k8s_configmap_client: K8SConfigM
                 async with AsyncExitStack() as exit_stack:
                     appgate_client = None
                     if not ctx.dry_run_mode:
+                        if ctx.device_id is None:
+                            raise AppgateException('No device id specified')
                         appgate_client = await exit_stack.enter_async_context(AppgateClient(
                             controller=ctx.controller,
                             user=ctx.user, password=ctx.password, provider=ctx.provider,

--- a/appgate/appgate.py
+++ b/appgate/appgate.py
@@ -279,7 +279,7 @@ def run_entity_loop(ctx: Context, crd: str, loop: asyncio.AbstractEventLoop,
                     # names are not unique between entities so we need to come up with a unique name
                     # now
                     mt = ev.object.metadata
-                    latest_entity_generation = k8s_configmap_client.read(entity_unique_id(kind, name))
+                    latest_entity_generation = k8s_configmap_client.read_entity_generation(entity_unique_id(kind, name))
                     if latest_entity_generation:
                         mt[APPGATE_METADATA_LATEST_GENERATION_FIELD] = latest_entity_generation.generation
                         mt[APPGATE_METADATA_MODIFICATION_FIELD] = dump_datetime(latest_entity_generation.modified)

--- a/appgate/appgate.py
+++ b/appgate/appgate.py
@@ -48,6 +48,7 @@ __all__ = [
 USER_ENV = 'APPGATE_OPERATOR_USER'
 PASSWORD_ENV = 'APPGATE_OPERATOR_PASSWORD'
 PROVIDER_ENV = 'APPGATE_OPERATOR_PROVIDER'
+DEVICE_ID_ENV = 'APPGATE_OPERATOR_DEVICE_ID'
 TIMEOUT_ENV = 'APPGATE_OPERATOR_TIMEOUT'
 HOST_ENV = 'APPGATE_OPERATOR_HOST'
 DRY_RUN_ENV = 'APPGATE_OPERATOR_DRY_RUN'
@@ -94,6 +95,7 @@ class Context:
     exclude_tags: Optional[FrozenSet[str]] = attrib(default=None)
     no_verify: bool = attrib(default=True)
     cafile: Optional[Path] = attrib(default=None)
+    device_id: Optional[str] = attrib(default=None)
 
 
 def save_cert(cert: str) -> Path:
@@ -129,6 +131,7 @@ def get_context(args: OperatorArguments,
     user = os.getenv(USER_ENV) or args.user
     password = os.getenv(PASSWORD_ENV) or args.password
     provider = os.getenv(PROVIDER_ENV) or args.provider
+    device_id = os.getenv(DEVICE_ID_ENV) or args.device_id
     controller = os.getenv(HOST_ENV) or args.host
     timeout = os.getenv(TIMEOUT_ENV) or args.timeout
     two_way_sync = os.getenv(TWO_WAY_SYNC_ENV) or ('1' if args.two_way_sync else '0')
@@ -163,6 +166,7 @@ def get_context(args: OperatorArguments,
                                  k8s_get_secret=k8s_get_secret)
     return Context(namespace=namespace, user=user, password=password,
                    provider=provider,
+                   device_id=device_id,
                    controller=controller, timeout=int(timeout),
                    dry_run_mode=dry_run_mode == '1',
                    cleanup_mode=cleanup_mode == '1',
@@ -221,6 +225,7 @@ async def get_current_appgate_state(ctx: Context) -> AppgateState:
                     ctx.namespace)
     async with AppgateClient(controller=ctx.controller, user=ctx.user,
                              password=ctx.password, provider=ctx.provider,
+                             device_id=ctx.device_id,
                              version=api_spec.api_version,
                              no_verify=ctx.no_verify,
                              cafile=ctx.cafile) as appgate_client:
@@ -372,6 +377,7 @@ async def main_loop(queue: Queue, ctx: Context, k8s_configmap_client: K8SConfigM
                         appgate_client = await exit_stack.enter_async_context(AppgateClient(
                             controller=ctx.controller,
                             user=ctx.user, password=ctx.password, provider=ctx.provider,
+                            device_id=ctx.device_id,
                             version=ctx.api_spec.api_version, no_verify=ctx.no_verify,
                             cafile=ctx.cafile))
                     else:

--- a/appgate/client.py
+++ b/appgate/client.py
@@ -124,7 +124,7 @@ class K8SConfigMapClient:
     def _device_id_key() -> str:
         return 'device-id'
 
-    async def _patch_key(self, key: str, value: Optional[str]) -> V1ObjectMeta:
+    async def _patch_key(self, key: str, value: Optional[str]) -> Optional[V1ObjectMeta]:
         body = V1ConfigMap(api_version='v1', kind='ConfigMap', data={
             key: value,
         })
@@ -136,10 +136,10 @@ class K8SConfigMapClient:
         )
         return configmap.metadata
 
-    async def _update_key(self, key: str, value: str) -> V1ObjectMeta:
+    async def _update_key(self, key: str, value: str) -> Optional[V1ObjectMeta]:
         return await self._patch_key(key, value)
 
-    async def _delete_key(self, key: str) -> V1ObjectMeta:
+    async def _delete_key(self, key: str) -> Optional[V1ObjectMeta]:
         return await self._patch_key(key, None)
 
     async def ensure_device_id(self) -> str:

--- a/appgate/client.py
+++ b/appgate/client.py
@@ -169,14 +169,15 @@ class K8SConfigMapClient:
 
 
 class AppgateClient:
-    def __init__(self, controller: str, user: str, password: str, provider: str, version: int,
+    def __init__(self, controller: str, user: str, password: str, provider: str,
+                 version: int, device_id: Optional[str] = None,
                  no_verify: bool = False, cafile: Optional[Path] = None) -> None:
         self.controller = controller
         self.user = user
         self.password = password
         self.provider = provider
         self._session = aiohttp.ClientSession()
-        self.device_id = str(uuid.uuid4())
+        self.device_id = device_id if device_id is not None else str(uuid.uuid4())
         self._token = None
         self.version = version
         self.no_verify = no_verify

--- a/appgate/client.py
+++ b/appgate/client.py
@@ -300,7 +300,7 @@ class AppgateClient:
             'password': self.password,
             'deviceId': self.device_id
         }
-        resp = await self.post('/admin/login', body=body)
+        resp = await self.post('admin/login', body=body)
         if resp:
             self._token = resp['token']
 

--- a/appgate/client.py
+++ b/appgate/client.py
@@ -161,10 +161,11 @@ class K8SConfigMapClient:
         if not self._configmap_mt:
             await self.init()
         prev_entry = self.get_entity_generation(key) or LatestEntityGeneration()
-        self._entries[key] = LatestEntityGeneration(
+        entry = LatestEntityGeneration(
             generation=generation or (prev_entry.generation + 1),
             modified=datetime.datetime.now().astimezone())
-        gen = dump_latest_entity_generation(self._entries[key])
+        gen = dump_latest_entity_generation(entry)
+        self._entries[key] = entry
         body = V1ConfigMap(api_version='v1', kind='ConfigMap', data={
             key: gen
         })
@@ -177,7 +178,7 @@ class K8SConfigMapClient:
             body=body
         )
         self._configmap_mt = new_configmap.metadata
-        return self._entries[key]
+        return entry
 
     async def delete(self, key: str) -> Optional[LatestEntityGeneration]:
         if not self._configmap_mt:

--- a/appgate/client.py
+++ b/appgate/client.py
@@ -164,7 +164,7 @@ class K8SConfigMapClient:
     async def update_entity_generation(self, key: str, generation: Optional[int]) -> Optional[LatestEntityGeneration]:
         if not self._configmap_mt:
             await self.init()
-        prev_entry = self.get_entity_generation(key)
+        prev_entry = self.get_entity_generation(key) or LatestEntityGeneration()
         entry = LatestEntityGeneration(
             generation=generation or (prev_entry.generation + 1),
             modified=datetime.datetime.now().astimezone())

--- a/appgate/client.py
+++ b/appgate/client.py
@@ -130,7 +130,7 @@ class K8SConfigMapClient:
         If that fails, generate one and store it in the configmap.
         """
         try:
-            device_id = self._data[self._device_id_key()]
+            return self._data[self._device_id_key()]
         except KeyError:
             device_id = str(uuid.uuid4())
             self._data[self._device_id_key()] = device_id

--- a/appgate/state.py
+++ b/appgate/state.py
@@ -121,8 +121,8 @@ def k8s_name(name: str) -> str:
 
 
 def dump_entity(entity: EntityWrapper, entity_type: str) -> Dict[str, Any]:
-    """
-    name sould match this regexp:
+    r"""
+    name should match this regexp:
        '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
     """
     entity_name = k8s_name(entity.name) if has_name(entity) else k8s_name(entity_type)

--- a/appgate/state.py
+++ b/appgate/state.py
@@ -19,7 +19,7 @@ from appgate.logger import log
 from appgate.openapi.parser import ENTITY_METADATA_ATTRIB_NAME
 from appgate.openapi.types import Entity_T, APISpec, PYTHON_TYPES, K8S_APPGATE_DOMAIN, K8S_APPGATE_VERSION, \
     APPGATE_METADATA_ATTRIB_NAME, APPGATE_METADATA_PASSWORD_FIELDS_FIELD
-from appgate.openapi.utils import is_entity_t, has_name, has_tag, is_target
+from appgate.openapi.utils import is_entity_t, has_name, has_tag
 
 __all__ = [
     'AppgateState',
@@ -295,8 +295,9 @@ async def plan_apply(plan: Plan, namespace: str, k8s_configmap_client: K8SConfig
             try:
                 await entity_client.post(e.value)
                 name = 'singleton' if e.value._entity_metadata.get('singleton', False) else e.name
-                await k8s_configmap_client.update(key=entity_unique_id(e.value.__class__.__name__, name),
-                                                  generation=e.value.appgate_metadata.current_generation)
+                await k8s_configmap_client.update_entity_generation(
+                    key=entity_unique_id(e.value.__class__.__name__, name),
+                    generation=e.value.appgate_metadata.current_generation)
             except Exception as err:
                 errors.add(f'{e.name} [{e.id}]: {str(err)}')
 
@@ -311,8 +312,9 @@ async def plan_apply(plan: Plan, namespace: str, k8s_configmap_client: K8SConfig
             try:
                 await entity_client.put(e.value)
                 name = 'singleton' if e.value._entity_metadata.get('singleton', False) else e.name
-                await k8s_configmap_client.update(key=entity_unique_id(e.value.__class__.__name__, name),
-                                                  generation=e.value.appgate_metadata.current_generation)
+                await k8s_configmap_client.update_entity_generation(
+                    key=entity_unique_id(e.value.__class__.__name__, name),
+                    generation=e.value.appgate_metadata.current_generation)
             except Exception as err:
                 errors.add(f'{e.name} [{e.id}]: {str(err)}')
 
@@ -322,7 +324,7 @@ async def plan_apply(plan: Plan, namespace: str, k8s_configmap_client: K8SConfig
             try:
                 await entity_client.delete(e.id)
                 name = 'singleton' if e.value._entity_metadata.get('singleton', False) else e.name
-                await k8s_configmap_client.delete(entity_unique_id(e.value.__class__.__name__, name))
+                await k8s_configmap_client.delete_entity_generation(entity_unique_id(e.value.__class__.__name__, name))
             except Exception as err:
                 errors.add(f'{e.name} [{e.id}]: {str(err)}')
 

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -34,6 +34,7 @@ class OperatorArguments:
     metadata_configmap: Optional[str] = attrib(default=None)
     no_verify: bool = attrib(default=False)
     cafile: Optional[Path] = attrib(default=None)
+    device_id: Optional[str] = attrib(default=None)
 
 
 @attrs(slots=True, frozen=True)


### PR DESCRIPTION
It can be set via the new `APPGATE_OPERATOR_DEVICE_ID` environment variable.
If it is not set the operator will attempt to read it from the metadata config map where we currently store entity generations.
If it is not set there either it will generate a new device id and store it inside the config map.

Closes GH-71.
Closes GH-102.