### PR TITLE
Add support for nullable attribute in Openspec API

### DIFF
--- a/appgate/bytes.py
+++ b/appgate/bytes.py
@@ -10,9 +10,9 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.x509 import load_pem_x509_certificate
 
 from appgate.customloaders import CustomFieldsEntityLoader
-from appgate.openapi.attribmaker import SimpleAttribMaker
+from appgate.openapi.attribmaker import AttribMaker
 from appgate.openapi.types import OpenApiDict, AttribType, AttributesDict, \
-    K8S_LOADERS_FIELD_NAME, InstanceMakerConfig, Entity_T, LoaderFunc
+    K8S_LOADERS_FIELD_NAME, EntityClassGeneratorConfig, Entity_T, LoaderFunc
 
 __all__ = [
     'checksum_attrib_maker',
@@ -71,7 +71,7 @@ def size_bytes(value: Any, data: str) -> int:
     return len(bytes_decoded)
 
 
-class BytesFieldAttribMaker(SimpleAttribMaker):
+class BytesFieldAttribMaker(AttribMaker):
     def __init__(self, name: str, tpe: type, base_tpe: type, default: Optional[AttribType],
                  factory: Optional[type], definition: OpenApiDict,
                  source_field: str,
@@ -80,8 +80,8 @@ class BytesFieldAttribMaker(SimpleAttribMaker):
         self.source_field = source_field
         self.loader = loader
 
-    def values(self, attributes: Dict[str, 'SimpleAttribMaker'], required_fields: List[str],
-               instance_maker_config: 'InstanceMakerConfig') -> AttributesDict:
+    def values(self, attributes: Dict[str, 'AttribMaker'], required_fields: List[str],
+               instance_maker_config: 'EntityClassGeneratorConfig') -> AttributesDict:
         values = super().values(attributes, required_fields, instance_maker_config)
         values['eq'] = True
         if 'metadata' not in values:

--- a/appgate/logger.py
+++ b/appgate/logger.py
@@ -28,9 +28,12 @@ class Logger:
         self.debug = self._log.debug
         self.warning = self._log.warning
         self.error = self._log.error
-        self.level = self._log.level
         self.getEffectiveLevel = self._log.getEffectiveLevel
         self.setLevel = self._log.setLevel
+
+    @property
+    def level(self) -> int:
+        return self._log.level
 
     def trace(self, message, *args, **kws) -> None:
         if self._log.isEnabledFor(TRACE_LEVEL):

--- a/appgate/openapi/attribmaker.py
+++ b/appgate/openapi/attribmaker.py
@@ -2,12 +2,14 @@ from uuid import uuid4
 from typing import Optional, Dict, Any, List
 
 from appgate.openapi.types import OpenApiDict, AttribType, AttributesDict, \
-    IGNORED_EQ_ATTRIBUTES, OpenApiParserException, InstanceMakerConfig, UUID_REFERENCE_FIELD, K8S_LOADERS_FIELD_NAME
-
+    IGNORED_EQ_ATTRIBUTES, OpenApiParserException, EntityClassGeneratorConfig, UUID_REFERENCE_FIELD
 write_only_formats = {'PEM', 'password'}
 
 
-class SimpleAttribMaker:
+class AttribMaker:
+    """
+    This class represents how to create a basic attribute in a final EntityClassGenerated.
+    """
     def __init__(self, name: str, tpe: type, base_tpe: type, default: Optional[AttribType],
                  factory: Optional[type], definition: OpenApiDict, repr: bool = True) -> None:
         self.base_tpe = base_tpe
@@ -39,8 +41,8 @@ class SimpleAttribMaker:
         """
         return self.factory is not None or self.default is not None
 
-    def values(self, attributes: Dict[str, 'SimpleAttribMaker'], required_fields: List[str],
-               instance_maker_config: InstanceMakerConfig) -> AttributesDict:
+    def values(self, attributes: Dict[str, 'AttribMaker'], required_fields: List[str],
+               instance_maker_config: EntityClassGeneratorConfig) -> AttributesDict:
         """
         Return the dictionary of values for this attribute. This will be used later
         to create entity classes.
@@ -102,13 +104,13 @@ class SimpleAttribMaker:
         return attribs
 
 
-class DeprecatedAttribMaker(SimpleAttribMaker):
+class DeprecatedAttribMaker(AttribMaker):
     pass
 
 
-class DefaultAttribMaker(SimpleAttribMaker):
-    def values(self, attributes: Dict[str, 'SimpleAttribMaker'], required_fields: List[str],
-               instance_maker_config: InstanceMakerConfig) -> AttributesDict:
+class DefaultAttribMaker(AttribMaker):
+    def values(self, attributes: Dict[str, 'AttribMaker'], required_fields: List[str],
+               instance_maker_config: EntityClassGeneratorConfig) -> AttributesDict:
         vs = {
             'type': Optional[self.tpe],
             'eq': False,

--- a/appgate/openapi/attribmaker.py
+++ b/appgate/openapi/attribmaker.py
@@ -36,6 +36,7 @@ class SimpleAttribMaker:
     def values(self, attributes: Dict[str, 'SimpleAttribMaker'], required_fields: List[str],
                instance_maker_config: InstanceMakerConfig) -> AttributesDict:
         required = self.name in required_fields
+        nullable = self.definition.get("nullable", False)
         definition = self.definition
         read_only = definition.get('readOnly', False)
         format = definition.get('format')
@@ -69,7 +70,7 @@ class SimpleAttribMaker:
             attribs['eq'] = False
 
         # Set type
-        if not required or read_only or write_only:
+        if (not required and nullable) or read_only or write_only:
             attribs['type'] = Optional[self.tpe]
             attribs['metadata']['type'] = str(Optional[self.tpe])
         elif required and (read_only or write_only):
@@ -84,8 +85,9 @@ class SimpleAttribMaker:
         elif self.factory and not (read_only or write_only):
             attribs['factory'] = self.factory
         elif not required or read_only or write_only:
-            attribs['default'] = definition.get('default',
-                                                None if (read_only or write_only) else self.default)
+            attribs['default'] = definition.get(
+                'default', None if (read_only or write_only) else self.default
+            )
         attribs['repr'] = self.repr
         return attribs
 

--- a/appgate/openapi/attribmaker.py
+++ b/appgate/openapi/attribmaker.py
@@ -20,21 +20,31 @@ class SimpleAttribMaker:
 
     @property
     def metadata(self) -> Dict[str, Any]:
+        """
+        Return the metadata for this attribute
+        """
         return self.definition.get('metadata', {})
 
     @property
     def is_password(self) -> bool:
+        """
+        Predicate to check if attrs is a password
+        """
         return False
 
     @property
     def has_default(self) -> bool:
         """
-        Checks if attrs as a default field value
+        Predicate to check if attrs as a default field value
         """
         return self.factory is not None or self.default is not None
 
     def values(self, attributes: Dict[str, 'SimpleAttribMaker'], required_fields: List[str],
                instance_maker_config: InstanceMakerConfig) -> AttributesDict:
+        """
+        Return the dictionary of values for this attribute. This will be used later
+        to create entity classes.
+        """
         required = self.name in required_fields
         nullable = self.definition.get("nullable", False)
         definition = self.definition

--- a/appgate/openapi/parser.py
+++ b/appgate/openapi/parser.py
@@ -104,6 +104,8 @@ class EntityClassGenerator:
                                                 instance_maker_config)),
                 filter(lambda kv: not isinstance(kv[1], DeprecatedAttribMaker),
                        self.attributes.items())))
+        log.trace('Creating new instance %s with values %s [required fields: %s]', self.name, values,
+                  instance_maker_config.definition.get('required', {}))
         # Add custom entity loaders if needed
         k8s_custom_entity_loaders = []
         appgate_custom_entity_loaders = []

--- a/appgate/openapi/parser.py
+++ b/appgate/openapi/parser.py
@@ -410,11 +410,15 @@ class Parser:
                                                 source_field=attrib_maker_config.definition['x-certificate-source'],
                                                 loader=K8S_LOADER.load)
             else:
+                # if nullable is specified then the type should be Optional
+                _factory = generated_entity.cls
+                if definition.get('nullable'):
+                    _factory = None
                 return SimpleAttribMaker(name=instance_maker_config.name,
                                          tpe=generated_entity.cls,
                                          base_tpe=generated_entity.cls,
                                          default=None,
-                                         factory=None,
+                                         factory=_factory,
                                          definition=instance_maker_config.definition)
         raise Exception(f'Unknown type for attribute {entity_name}.{attrib_name}: {definition}')
 

--- a/appgate/openapi/parser.py
+++ b/appgate/openapi/parser.py
@@ -422,9 +422,10 @@ class Parser:
                                                 source_field=attrib_maker_config.definition['x-certificate-source'],
                                                 loader=K8S_LOADER.load)
             else:
-                # if nullable is specified then the type should be Optional
-                _factory = generated_entity.cls
-                if definition.get('nullable'):
+                # if the object is not nullable and it does not have any required argument
+                # create a factory for it.
+                _factory: Optional[type] = generated_entity.cls
+                if definition.get('nullable') or definition.get('required'):
                     _factory = None
                 return AttribMaker(name=instance_maker_config.name,
                                    tpe=generated_entity.cls,

--- a/appgate/openapi/types.py
+++ b/appgate/openapi/types.py
@@ -209,7 +209,7 @@ class EntitiesContext:
 
 @attrs()
 class AttribMakerConfig:
-    instance_maker_config: 'InstanceMakerConfig' = attrib()
+    instance_maker_config: 'EntityClassGeneratorConfig' = attrib()
     name: str = attrib()
     definition: OpenApiDict = attrib()
 
@@ -224,7 +224,11 @@ class AttribMakerConfig:
 
 
 @attrs()
-class InstanceMakerConfig:
+class EntityClassGeneratorConfig:
+    """
+    Class used to store information of the EntityClass to create.
+    This class is used when a new Entity class is generated.
+    """
     name: str = attrib()
     entity_name: str = attrib()
     definition: OpenApiDict = attrib()

--- a/appgate/secrets.py
+++ b/appgate/secrets.py
@@ -8,8 +8,8 @@ from cryptography.fernet import Fernet
 from kubernetes.client import CoreV1Api
 
 from appgate.customloaders import CustomAttribLoader, CustomEntityLoader
-from appgate.openapi.attribmaker import SimpleAttribMaker
-from appgate.openapi.types import AttribType, OpenApiDict, AttributesDict, InstanceMakerConfig, \
+from appgate.openapi.attribmaker import AttribMaker
+from appgate.openapi.types import AttribType, OpenApiDict, AttributesDict, EntityClassGeneratorConfig, \
     K8S_LOADERS_FIELD_NAME, Entity_T, APPGATE_LOADERS_FIELD_NAME
 from appgate.openapi.utils import get_passwords
 
@@ -142,7 +142,7 @@ def appgate_secret_load(value: OpenApiDict, secrets_cipher: Optional[Fernet],
     return appgate_secret.decrypt()
 
 
-class PasswordAttribMaker(SimpleAttribMaker):
+class PasswordAttribMaker(AttribMaker):
     def __init__(self, name: str, tpe: type, base_tpe: type, default: Optional[AttribType],
                  factory: Optional[type], definition: OpenApiDict,
                  secrets_cipher: Optional[Fernet],
@@ -151,8 +151,8 @@ class PasswordAttribMaker(SimpleAttribMaker):
         self.secrets_cipher = secrets_cipher
         self.k8s_get_client = k8s_get_client
 
-    def values(self, attributes: Dict[str, 'SimpleAttribMaker'], required_fields: List[str],
-               instance_maker_config: 'InstanceMakerConfig') -> AttributesDict:
+    def values(self, attributes: Dict[str, 'AttribMaker'], required_fields: List[str],
+               instance_maker_config: 'EntityClassGeneratorConfig') -> AttributesDict:
         # Compare passwords if compare_secrets was enabled
         values = super().values(attributes, required_fields, instance_maker_config)
         values['eq'] = False

--- a/tests/resources/test_entity.yaml
+++ b/tests/resources/test_entity.yaml
@@ -38,6 +38,8 @@ paths:
     $ref: '#/entity-cert'
   /entity-dep-nested:
     $ref: '#/entity-dep-nested'
+  /entity-dep-nested-nullable:
+    $ref: '#/entity-dep-nested-nullable'
     
 entity-test1:
   get:
@@ -263,6 +265,21 @@ entity-dep-nested:
         application/json:
           schema:
             $ref: '#/definitions/EntityDepNested7'
+
+entity-dep-nested-nullable:
+  get:
+    responses:
+      '200':
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/EntityTestList'
+  post:
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/definitions/EntityDepNestedNullable'
 
 definitions:
   EntityTestList:
@@ -558,3 +575,130 @@ definitions:
             x-uuid-ref:
               - EntityDep2
               - EntityDep1
+      actions:
+        type: array
+        items:
+          type: object
+          required:
+            - subtype
+            - action
+            - hosts
+          properties:
+            subtype:
+              type: string
+              enum:
+                - icmp_up
+                - icmp_down
+                - icmpv6_up
+                - icmpv6_down
+                - udp_up
+                - udp_down
+                - tcp_up
+                - tcp_down
+                - ah_up
+                - ah_down
+                - esp_up
+                - esp_down
+                - gre_up
+                - gre_down
+                - http_up
+            action:
+              type: string
+              enum:
+                - allow
+                - block
+                - alert
+            hosts:
+              type: array
+              items:
+                type: string
+              example:
+                - 10.0.0.1
+                - 10.0.0.0/24
+                - hostname.company.com
+                - 'dns://hostname.company.com'
+                - 'aws://security-group:accounting'
+            ports:
+              type: array
+              items:
+                type: string
+              example:
+                - 80
+                - 1024-65535
+            monitor:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  default: false
+                timeout:
+                  type: integer
+                  default: 30
+  EntityDepNestedNullable:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      name:
+        type: string
+      actions:
+        type: array
+        items:
+          type: object
+          required:
+            - subtype
+            - action
+            - hosts
+          properties:
+            subtype:
+              type: string
+              enum:
+                - icmp_up
+                - icmp_down
+                - icmpv6_up
+                - icmpv6_down
+                - udp_up
+                - udp_down
+                - tcp_up
+                - tcp_down
+                - ah_up
+                - ah_down
+                - esp_up
+                - esp_down
+                - gre_up
+                - gre_down
+                - http_up
+            action:
+              type: string
+              enum:
+                - allow
+                - block
+                - alert
+            hosts:
+              type: array
+              items:
+                type: string
+              example:
+                - 10.0.0.1
+                - 10.0.0.0/24
+                - hostname.company.com
+                - 'dns://hostname.company.com'
+                - 'aws://security-group:accounting'
+            ports:
+              type: array
+              items:
+                type: string
+              example:
+                - 80
+                - 1024-65535
+            monitor:
+              type: object
+              nullable: true
+              properties:
+                enabled:
+                  type: boolean
+                  default: false
+                timeout:
+                  type: integer
+                  default: 30

--- a/tests/resources/test_entity.yaml
+++ b/tests/resources/test_entity.yaml
@@ -692,7 +692,7 @@ definitions:
               example:
                 - 80
                 - 1024-65535
-            monitor:
+            monitor_nullable:
               type: object
               nullable: true
               properties:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -130,6 +130,86 @@ def test_loader_3():
                             appgate_metadata=AppgateMetadata(uuid='333-333-333-333-333'))
 
 
+def test_loader_4():
+    """
+    Test load nested fields with sane default values.
+    These fields are not Optional, they just implement a default factory method
+    """
+    api_spec = load_test_open_api_spec(secrets_key=None, reload=True)
+    EntityDepNested7 = api_spec.entities['EntityDepNested7'].cls
+    EntityDepNested7_Deps = api_spec.entities['EntityDepNested7_Deps'].cls
+    EntityDepNested7_Actions = api_spec.entities['EntityDepNested7_Actions'].cls
+    EntityDepNested7_Actions_Monitor = api_spec.entities['EntityDepNested7_Actions_Monitor'].cls
+
+    entity_7 = {
+        'name': 'n1',
+        'deps': {
+            'field1': 'f1',
+            'field2': 'f2'
+        },
+        'actions': [
+            {
+                'subtype': 'tcp_up',
+                'action': 'allow',
+                'hosts': ['h1', 'h2'],
+                'ports': ['666'],
+            }
+        ]
+    }
+
+    e = K8S_LOADER.load(entity_7, None, EntityDepNested7)
+    assert e == EntityDepNested7(name='n1',
+                                 deps=EntityDepNested7_Deps(
+                                     field1='f1', field2='f2'
+                                 ),
+                                 actions=frozenset({
+                                     EntityDepNested7_Actions(
+                                         subtype='tcp_up',
+                                         action='allow',
+                                         hosts=frozenset({'h1', 'h2'}),
+                                         ports=frozenset({'666'}),
+                                         monitor=EntityDepNested7_Actions_Monitor())
+                                 }))
+
+
+def test_loader_5():
+    """
+    Test load nested fields with sane default values.
+    These fields are not Optional, they just implement a default factory method
+    """
+    api_spec = load_test_open_api_spec(secrets_key=None, reload=True)
+    EntityDepNestedNullable = api_spec.entities['EntityDepNestedNullable'].cls
+    EntityDepNestedNullable_Actions = api_spec.entities['EntityDepNestedNullable_Actions'].cls
+    EntityDepNestedNullable_Actions_Monitor = api_spec.entities['EntityDepNestedNullable_Actions_Monitor'].cls
+
+    entity_nullable = {
+        'name': 'n1',
+        'deps': {
+            'field1': 'f1',
+            'field2': 'f2'
+        },
+        'actions': [
+            {
+                'subtype': 'tcp_up',
+                'action': 'allow',
+                'hosts': ['h1', 'h2'],
+                'ports': ['666'],
+            }
+        ]
+    }
+
+    e = K8S_LOADER.load(entity_nullable, None, EntityDepNestedNullable)
+    assert e == EntityDepNestedNullable(name='n1',
+                                        actions=frozenset({
+                                            EntityDepNestedNullable_Actions(
+                                                subtype='tcp_up',
+                                                action='allow',
+                                                hosts=frozenset({'h1', 'h2'}),
+                                                ports=frozenset({'666'}),
+                                                monitor=None)
+                                        }))
+
+
 def test_dumper_1():
     EntityTest1 = load_test_open_api_spec(secrets_key=None,
                                           reload=True).entities['EntityTest1'].cls

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -180,7 +180,6 @@ def test_loader_5():
     api_spec = load_test_open_api_spec(secrets_key=None, reload=True)
     EntityDepNestedNullable = api_spec.entities['EntityDepNestedNullable'].cls
     EntityDepNestedNullable_Actions = api_spec.entities['EntityDepNestedNullable_Actions'].cls
-    EntityDepNestedNullable_Actions_Monitor = api_spec.entities['EntityDepNestedNullable_Actions_Monitor'].cls
 
     entity_nullable = {
         'name': 'n1',
@@ -206,7 +205,7 @@ def test_loader_5():
                                                 action='allow',
                                                 hosts=frozenset({'h1', 'h2'}),
                                                 ports=frozenset({'666'}),
-                                                monitor=None)
+                                                monitor_nullable=None)
                                         }))
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,6 +35,7 @@ TestSpec = {
     '/entity-dep-6': 'EntityDep6',
     '/entity-cert': 'EntityCert',
     '/entity-dep-nested': 'EntityDepNested7',
+    '/entity-dep-nested-nullable': 'EntityDepNestedNullable'
 }
 PEM_TEST = '''-----BEGIN CERTIFICATE-----
 MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG


### PR DESCRIPTION
Fields defined as nullable will be of type `Optional[baseType]` while if they are not nullable the type will be `baseType` and a default factory method will be assigned