### PR TITLE
Revert "kubernetes depends on requests, force requests to use chardet…

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,8 +2,4 @@ aiohttp>=3.8.1
 attrs>=20.3.0
 cryptography>=36.0.1
 kubernetes>=12.0.1
-# kubernetes depends on requests,
-# we need to force an optional requests feature to work around some log spam, see:
-# https://github.com/psf/requests/issues/5871
-requests[use_chardet_on_py3]
 typedload==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ attrs==21.4.0
 cachetools==4.2.4
 certifi==2021.10.8
 cffi==1.15.0
-chardet==4.0.0
 charset-normalizer==2.0.9
 cryptography==36.0.1
 frozenlist==1.2.0


### PR DESCRIPTION
Reverts appgate/sdp-operator#129

Turns out the problem wasn't that, we are using `logging.basicConfig` which affects *all* loggers.