### PR TITLE
Make the operator to fail when there are erros parsing k8s entities

### DIFF
--- a/appgate/openapi/types.py
+++ b/appgate/openapi/types.py
@@ -93,6 +93,7 @@ class PlatformType(enum.Enum):
 class AppgateException(Exception):
     def __init__(self, message: Optional[str] = None) -> None:
         self.message = message
+        super(AppgateException, self).__init__(message)
 
 
 class OpenApiParserException(Exception):
@@ -107,7 +108,7 @@ class AppgateTypedloadException(AppgateException):
         value: Optional[Any] = None,
         type_: Optional[Type] = None,
     ) -> None:
-        super().__init__(description)
+        super().__init__(message=description)
         self.platform_type = platform_type
         self.value = value
         self.type_ = type_

--- a/appgate/openapi/types.py
+++ b/appgate/openapi/types.py
@@ -1,4 +1,5 @@
 import datetime
+import enum
 import itertools
 import re
 from functools import cached_property
@@ -13,6 +14,7 @@ from typing import (
     Union,
     Iterator,
     Tuple,
+    Type,
 )
 
 from graphlib import TopologicalSorter
@@ -20,6 +22,7 @@ from graphlib import TopologicalSorter
 from attr import attrib, attrs, Attribute, evolve
 
 from appgate.logger import log
+
 
 SPEC_ENTITIES = {
     "/sites": "Site",
@@ -81,6 +84,12 @@ def normalize_attrib_name(name: str) -> str:
     return name
 
 
+class PlatformType(enum.Enum):
+    K8S = 1
+    APPGATE = 2
+    DIFF = 3
+
+
 class AppgateException(Exception):
     def __init__(self, message: Optional[str] = None) -> None:
         self.message = message
@@ -88,6 +97,20 @@ class AppgateException(Exception):
 
 class OpenApiParserException(Exception):
     pass
+
+
+class AppgateTypedloadException(AppgateException):
+    def __init__(
+        self,
+        description: str,
+        platform_type: PlatformType,
+        value: Optional[Any] = None,
+        type_: Optional[Type] = None,
+    ) -> None:
+        super().__init__(description)
+        self.platform_type = platform_type
+        self.value = value
+        self.type_ = type_
 
 
 @attrs(frozen=True, slots=True)

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -2,7 +2,7 @@ import datetime
 import enum
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Any, FrozenSet, Optional, List, Set, Literal
+from typing import Dict, Any, FrozenSet, Optional, List, Set, Literal, Union
 from attr import attrib, attrs, evolve
 
 from appgate.openapi.types import Entity_T, APISpec
@@ -13,6 +13,8 @@ __all__ = [
     "K8SEvent",
     "EventObject",
     "AppgateEvent",
+    "AppgateEventError",
+    "AppgateEventSuccess",
     "EntityWrapper",
     "has_tag",
     "is_target",
@@ -64,9 +66,19 @@ class K8SEvent:
 
 
 @attrs(slots=True, frozen=True)
-class AppgateEvent:
+class AppgateEventError:
+    name: str = attrib()
+    kind: str = attrib()
+    error: str = attrib()
+
+
+@attrs(slots=True, frozen=True)
+class AppgateEventSuccess:
     op: Literal["ADDED", "DELETED", "MODIFIED"] = attrib()
     entity: Entity_T = attrib()
+
+
+AppgateEvent = Union[AppgateEventError, AppgateEventSuccess]
 
 
 class EntityWrapper:

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -1,4 +1,5 @@
 import datetime
+import enum
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, Any, FrozenSet, Optional, List, Set, Literal

--- a/tests/test_appgatesecrets.py
+++ b/tests/test_appgatesecrets.py
@@ -183,11 +183,9 @@ def test_get_appgate_secret_k8s_simple_load_missing_key():
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
-    with pytest.raises(
-        AppgateTypedloadException,
-        match="Unable to get secret: secret-storage.field-one",
-    ):
+    with pytest.raises(AppgateTypedloadException) as exc:
         K8S_LOADER.load(data, None, EntityTest2)
+    assert "Unable to get secret: secret-storage.field-one" in str(exc)
 
 
 def test_get_secret_read_entity_without_password():

--- a/tests/test_appgatesecrets.py
+++ b/tests/test_appgatesecrets.py
@@ -1,12 +1,10 @@
 import pytest
-from typedload.exceptions import TypedloadException
 
 from appgate.attrs import (
     APPGATE_LOADER,
     K8S_LOADER,
     K8S_DUMPER,
     APPGATE_DUMPER,
-    parse_datetime,
 )
 from appgate.secrets import (
     get_appgate_secret,
@@ -16,6 +14,7 @@ from appgate.secrets import (
     AppgateSecretPlainText,
 )
 from appgate.types import EntityWrapper
+from appgate.openapi.types import AppgateTypedloadException
 from tests.utils import (
     load_test_open_api_spec,
     ENCRYPTED_PASSWORD,
@@ -185,7 +184,8 @@ def test_get_appgate_secret_k8s_simple_load_missing_key():
         "fieldThree": "this is a field",
     }
     with pytest.raises(
-        TypedloadException, match="Unable to get secret: secret-storage.field-one"
+        AppgateTypedloadException,
+        match="Unable to get secret: secret-storage.field-one",
     ):
         K8S_LOADER.load(data, None, EntityTest2)
 


### PR DESCRIPTION
Example log now (when failing to parse an entity with PEM):

```

2022-01-07 11:53:48,564 [ERROR] [trustedcertificates/sdp-demo] Unable to parse event with name Test Cert of type TrustedCertificate
2022-01-07 11:53:48,564 [ERROR] [trustedcertificates/sdp-demo]    !!! Error message: Unable to load PEM file. See https://cryptography.io/en/latest/faq.html#why-can-t-i-import-my-pem-file for more details. InvalidData(InvalidLength)
Path: .
2022-01-07 11:53:48,565 [ERROR] [trustedcertificates/sdp-demo]    !!! Error when loading from: PlatformType.K8S
2022-01-07 11:53:48,565 [ERROR] [trustedcertificates/sdp-demo]    !!! Error when loading type: TrustedCertificate
2022-01-07 11:53:48,565 [ERROR] [trustedcertificates/sdp-demo]    !!! Error when loading value: {'name': 'Test Cert', 'pem': '-----BEGIN CERTIFICATE-----\nWRONGDATAIBAQCo\nK5txC5iu1QHEDlPtABqOx/zF0XFzP0Z7jMDvo41vSE3Dhj3hn2S+pat6Scb2/I4s\nY2dNF2UUid8gvc3eXQuKOhVWGKEgEDBtkw1ItZwSHstMv/WCUV5z9OmE0y20BJ2U\n03yh3DtiDC2N03kIQvyABtn1iBbuGHjTLk3gsz/UtEV6Bvw8yv7lyrIR+7w0LbWj\nW+nG0yhs05gZWwO4Oi5UeBabfqzu7Z7W5ucjdrtJjvDGQnGRTwKuV2yYuCLi96md\nDATA\n-----END CERTIFICATE-----\n', 'notes': 'got-env-vc.agi.appgate.com', 'tags': ['watch-operator'], 'appgate_metadata': {'generation': 2, 'latestGeneration': 1, 'modificationTimestamp': '2022-01-07T10:44:17.526Z'}}
^C2022-01-07 11:53:49,742 [INFO] Interrupted by user.
```

The operator will also exit if there is at least one error when parsing k8s events. It will try to accumulate as many errors as possible before crashing.