### PR TITLE
Upgrade black to 22.3.0 for _unicodefun import error

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,6 @@
 mypy==0.930
 mypy-extensions==0.4.3
 pytest==6.2.4
-black==21.12b0
+black==22.3.0
 # type stubs
 types-PyYAML==6.0.1


### PR DESCRIPTION
Upgrade black to 22.3.0 

https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click

```
root@29c1a1c82f58:/build# black --check --diff appgate tests
Traceback (most recent call last):
  File "/usr/local/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/usr/local/lib/python3.9/site-packages/black/__init__.py", line 1372, in patched_main
    patch_click()
  File "/usr/local/lib/python3.9/site-packages/black/__init__.py", line 1358, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/usr/local/lib/python3.9/site-packages/click/__init__.py)
root@29c1a1c82f58:/build# 
exit
make: *** [docker-shell] Error 1
```