### PR TITLE
Support IdentityProvider in the SDP Operator

### DIFF
--- a/appgate/attrs.py
+++ b/appgate/attrs.py
@@ -15,6 +15,7 @@ from appgate.customloaders import (
     CustomAttribLoader,
     CustomEntityLoader,
 )
+from appgate.logger import log
 from appgate.openapi.types import (
     Entity_T,
     ENTITY_METADATA_ATTRIB_NAME,

--- a/appgate/discriminator.py
+++ b/appgate/discriminator.py
@@ -39,7 +39,7 @@ def get_discriminator_maker_config(
             definition=definition,
             singleton=attrib_maker_config.instance_maker_config.singleton,
             api_path=None,
-            level=current_level + 1,
+            level=current_level,
         )
         config.append(discriminator_maker_config)
     return config
@@ -77,8 +77,10 @@ class DiscriminatorAttribMaker(AttribMaker):
         def validate_fields(original, entity: Entity_T) -> Entity_T:
             type = original["type"]
 
-            # Check if there are missing fields required for this type
-            required_fields = set(self.definition_map[type]["required"])
+            # Check if there are missing fields required for this type. Exclude readOnly attributes.
+            required_fields = set(
+                k for k in self.definition_map[type]["required"] if k != "id"
+            )
             missing_fields = required_fields.difference(set(original.keys()))
             if len(missing_fields) > 0:
                 raise TypeError(

--- a/appgate/discriminator.py
+++ b/appgate/discriminator.py
@@ -1,0 +1,104 @@
+import pprint
+from typing import List, Optional, Dict
+
+from attr import evolve
+
+from appgate.customloaders import CustomEntityLoader
+from appgate.logger import log
+from appgate.openapi.attribmaker import AttribMaker
+from appgate.openapi.types import (
+    AttribMakerConfig,
+    EntityClassGeneratorConfig,
+    AttribType,
+    OpenApiDict,
+    AttributesDict,
+    K8S_LOADERS_FIELD_NAME,
+    APPGATE_LOADERS_FIELD_NAME,
+    Entity_T,
+)
+
+
+def get_discriminator_maker_config(
+    discriminator: dict,
+    attrib_maker_config: AttribMakerConfig,
+    entity: str,
+    attrib_name: str,
+) -> List[EntityClassGeneratorConfig]:
+    config = []
+    for discriminator_entity, definition in discriminator["mapping"].items():
+        log.info(
+            "Creating object type for entity %s and attribute %s",
+            f"{entity}_{discriminator_entity}",
+            attrib_name,
+        )
+
+        current_level = attrib_maker_config.instance_maker_config.level
+        discriminator_maker_config = EntityClassGeneratorConfig(
+            name=discriminator_entity,
+            entity_name=f"{entity}_{discriminator_entity}",
+            definition=definition,
+            singleton=attrib_maker_config.instance_maker_config.singleton,
+            api_path=None,
+            level=current_level + 1,
+        )
+        config.append(discriminator_maker_config)
+    return config
+
+
+class DiscriminatorAttribMaker(AttribMaker):
+    def __init__(
+        self,
+        name: str,
+        tpe: type,
+        base_tpe: type,
+        default: Optional[AttribType],
+        factory: Optional[type],
+        top_level_definition: OpenApiDict,
+        discriminator_property_name: str,
+        entity_map: dict,
+        definition_map: dict,
+        config_map: dict,
+        repr: bool = True,
+    ) -> None:
+        super().__init__(
+            name, tpe, base_tpe, default, factory, top_level_definition, repr
+        )
+        self.discriminator_property_name = discriminator_property_name
+        self.entity_map = entity_map
+        self.definition_map = definition_map
+        self.config_map = config_map
+
+    def values(
+        self,
+        attributes: Dict[str, "AttribMaker"],
+        required_fields: List[str],
+        instance_maker_config: EntityClassGeneratorConfig,
+    ) -> AttributesDict:
+        def validate_fields(original, entity: Entity_T) -> Entity_T:
+            type = original["type"]
+
+            # Check if there are missing fields required for this type
+            required_fields = set(self.definition_map[type]["required"])
+            missing_fields = required_fields.difference(set(original.keys()))
+            if len(missing_fields) > 0:
+                raise TypeError(
+                    f"Missing required fields when loading entity: {', '.join(missing_fields)}"
+                )
+
+            return entity
+
+        values = super().values(attributes, required_fields, instance_maker_config)
+        values["eq"] = False
+
+        if "metadata" not in values:
+            values["metadata"] = {}
+
+        values["metadata"][APPGATE_LOADERS_FIELD_NAME] = [
+            CustomEntityLoader(loader=validate_fields)
+        ]
+
+        values["metadata"][K8S_LOADERS_FIELD_NAME] = [
+            CustomEntityLoader(loader=validate_fields)
+        ]
+
+        return values

--- a/tests/resources/crd/v12/identityprovider.yaml
+++ b/tests/resources/crd/v12/identityprovider.yaml
@@ -18,12 +18,34 @@ spec:
         properties:
           spec:
             properties:
+              adminDistinguishedName:
+                default: ''
+                type: string
+              adminPassword:
+                default: null
+                type: string
               adminProvider:
                 default: false
                 type: boolean
+              audience:
+                default: ''
+                type: string
+              authenticationProtocol:
+                default: CHAP
+                type: string
+              baseDn:
+                default: ''
+                type: string
               blockLocalDnsRequests:
                 default: false
                 type: boolean
+              caCertificates:
+                items:
+                  type: string
+                type: array
+              certificateUserAttribute:
+                default: userPrincipalName
+                type: string
               claimMappings:
                 items:
                   properties:
@@ -54,6 +76,9 @@ spec:
                   - claimName
                   type: object
                 type: array
+              decryptionKey:
+                default: ''
+                type: string
               default:
                 default: false
                 type: boolean
@@ -65,6 +90,10 @@ spec:
                 items:
                   type: string
                 type: array
+              hostnames:
+                items:
+                  type: string
+                type: array
               inactivityTimeoutMinutes:
                 default: 0
                 type: integer
@@ -72,10 +101,25 @@ spec:
                 type: string
               ipPoolV6:
                 type: string
+              issuer:
+                default: ''
+                type: string
+              membershipBaseDn:
+                default: ''
+                type: string
+              membershipFilter:
+                default: (objectCategory=group)
+                type: string
+              minPasswordLength:
+                default: 0
+                type: integer
               name:
                 type: string
               notes:
                 default: ''
+                type: string
+              objectClass:
+                default: user
                 type: string
               onBoarding2FA:
                 properties:
@@ -150,11 +194,54 @@ spec:
                   - platform
                   type: object
                 type: array
+              passwordWarning:
+                properties:
+                  enabled:
+                    type: boolean
+                  id:
+                    default: IdentityProvider_Passwordwarning
+                    type: string
+                  message:
+                    default: ''
+                    type: string
+                  name:
+                    default: IdentityProvider_Passwordwarning
+                    type: string
+                  tags:
+                    default:
+                    - builtin
+                    items:
+                      type: string
+                    type: array
+                  thresholdDays:
+                    default: 5
+                    type: integer
+                type: object
+              port:
+                type: integer
+              providerCertificate:
+                default: ''
+                type: string
+              redirectUrl:
+                default: ''
+                type: string
+              sharedSecret:
+                default: null
+                type: string
+              sslEnabled:
+                default: false
+                type: boolean
               tags:
                 items:
                   type: string
                 type: array
               type:
+                type: string
+              userLockoutThreshold:
+                default: 5
+                type: integer
+              usernameAttribute:
+                default: sAMAccountName
                 type: string
             required:
             - name

--- a/tests/resources/crd/v13/identityprovider.yaml
+++ b/tests/resources/crd/v13/identityprovider.yaml
@@ -18,12 +18,34 @@ spec:
         properties:
           spec:
             properties:
+              adminDistinguishedName:
+                default: ''
+                type: string
+              adminPassword:
+                default: null
+                type: string
               adminProvider:
                 default: false
                 type: boolean
+              audience:
+                default: ''
+                type: string
+              authenticationProtocol:
+                default: CHAP
+                type: string
+              baseDn:
+                default: ''
+                type: string
               blockLocalDnsRequests:
                 default: false
                 type: boolean
+              caCertificates:
+                items:
+                  type: string
+                type: array
+              certificateUserAttribute:
+                default: userPrincipalName
+                type: string
               claimMappings:
                 items:
                   properties:
@@ -42,6 +64,9 @@ spec:
                   - claimName
                   type: object
                 type: array
+              decryptionKey:
+                default: ''
+                type: string
               default:
                 default: false
                 type: boolean
@@ -53,6 +78,12 @@ spec:
                 items:
                   type: string
                 type: array
+              forceAuthn:
+                type: boolean
+              hostnames:
+                items:
+                  type: string
+                type: array
               inactivityTimeoutMinutes:
                 default: 0
                 type: integer
@@ -60,10 +91,25 @@ spec:
                 type: string
               ipPoolV6:
                 type: string
+              issuer:
+                default: ''
+                type: string
+              membershipBaseDn:
+                default: ''
+                type: string
+              membershipFilter:
+                default: (objectCategory=group)
+                type: string
+              minPasswordLength:
+                default: 0
+                type: integer
               name:
                 type: string
               notes:
                 default: ''
+                type: string
+              objectClass:
+                default: user
                 type: string
               onBoarding2FA:
                 properties:
@@ -105,11 +151,42 @@ spec:
                   - platform
                   type: object
                 type: array
+              passwordWarning:
+                properties:
+                  enabled:
+                    type: boolean
+                  message:
+                    default: ''
+                    type: string
+                  thresholdDays:
+                    default: 5
+                    type: integer
+                type: object
+              port:
+                type: integer
+              providerCertificate:
+                default: ''
+                type: string
+              redirectUrl:
+                default: ''
+                type: string
+              sharedSecret:
+                default: null
+                type: string
+              sslEnabled:
+                default: false
+                type: boolean
               tags:
                 items:
                   type: string
                 type: array
               type:
+                type: string
+              userLockoutThreshold:
+                default: 5
+                type: integer
+              usernameAttribute:
+                default: sAMAccountName
                 type: string
             required:
             - name

--- a/tests/resources/crd/v14/identityprovider.yaml
+++ b/tests/resources/crd/v14/identityprovider.yaml
@@ -18,12 +18,37 @@ spec:
         properties:
           spec:
             properties:
+              adminDistinguishedName:
+                default: ''
+                type: string
+              adminPassword:
+                default: null
+                type: string
               adminProvider:
                 default: false
                 type: boolean
+              audience:
+                default: ''
+                type: string
+              authenticationProtocol:
+                default: CHAP
+                type: string
+              baseDn:
+                default: ''
+                type: string
               blockLocalDnsRequests:
                 default: false
                 type: boolean
+              caCertificates:
+                items:
+                  type: string
+                type: array
+              certificateAttribute:
+                default: ''
+                type: string
+              certificateUserAttribute:
+                default: userPrincipalName
+                type: string
               claimMappings:
                 items:
                   properties:
@@ -42,6 +67,9 @@ spec:
                   - claimName
                   type: object
                 type: array
+              decryptionKey:
+                default: ''
+                type: string
               default:
                 default: false
                 type: boolean
@@ -53,6 +81,12 @@ spec:
                 items:
                   type: string
                 type: array
+              forceAuthn:
+                type: boolean
+              hostnames:
+                items:
+                  type: string
+                type: array
               inactivityTimeoutMinutes:
                 default: 0
                 type: integer
@@ -60,10 +94,25 @@ spec:
                 type: string
               ipPoolV6:
                 type: string
+              issuer:
+                default: ''
+                type: string
+              membershipBaseDn:
+                default: ''
+                type: string
+              membershipFilter:
+                default: (objectCategory=group)
+                type: string
+              minPasswordLength:
+                default: 0
+                type: integer
               name:
                 type: string
               notes:
                 default: ''
+                type: string
+              objectClass:
+                default: user
                 type: string
               onBoarding2FA:
                 properties:
@@ -110,16 +159,49 @@ spec:
                   - platform
                   type: object
                 type: array
+              passwordWarning:
+                properties:
+                  enabled:
+                    type: boolean
+                  message:
+                    default: ''
+                    type: string
+                  thresholdDays:
+                    default: 5
+                    type: integer
+                type: object
+              port:
+                type: integer
+              providerCertificate:
+                default: ''
+                type: string
+              redirectUrl:
+                default: ''
+                type: string
+              sharedSecret:
+                default: null
+                type: string
+              skipX509ExternalChecks:
+                type: boolean
+              sslEnabled:
+                default: false
+                type: boolean
               tags:
                 items:
                   type: string
                 type: array
               type:
                 type: string
+              userLockoutThreshold:
+                default: 5
+                type: integer
               userScripts:
                 items:
                   type: string
                 type: array
+              usernameAttribute:
+                default: sAMAccountName
+                type: string
             required:
             - name
             - type

--- a/tests/resources/crd/v15/identityprovider.yaml
+++ b/tests/resources/crd/v15/identityprovider.yaml
@@ -18,12 +18,37 @@ spec:
         properties:
           spec:
             properties:
+              adminDistinguishedName:
+                default: ''
+                type: string
+              adminPassword:
+                default: null
+                type: string
               adminProvider:
                 default: false
                 type: boolean
+              audience:
+                default: ''
+                type: string
+              authenticationProtocol:
+                default: CHAP
+                type: string
+              baseDn:
+                default: ''
+                type: string
               blockLocalDnsRequests:
                 default: false
                 type: boolean
+              caCertificates:
+                items:
+                  type: string
+                type: array
+              certificateAttribute:
+                default: ''
+                type: string
+              certificateUserAttribute:
+                default: userPrincipalName
+                type: string
               claimMappings:
                 items:
                   properties:
@@ -42,6 +67,9 @@ spec:
                   - claimName
                   type: object
                 type: array
+              decryptionKey:
+                default: ''
+                type: string
               dnsSearchDomains:
                 items:
                   type: string
@@ -52,6 +80,12 @@ spec:
                 type: array
               enforceWindowsNetworkProfileAsDomain:
                 type: boolean
+              forceAuthn:
+                type: boolean
+              hostnames:
+                items:
+                  type: string
+                type: array
               inactivityTimeoutMinutes:
                 default: 0
                 type: integer
@@ -59,10 +93,25 @@ spec:
                 type: string
               ipPoolV6:
                 type: string
+              issuer:
+                default: ''
+                type: string
+              membershipBaseDn:
+                default: ''
+                type: string
+              membershipFilter:
+                default: (objectCategory=group)
+                type: string
+              minPasswordLength:
+                default: 0
+                type: integer
               name:
                 type: string
               notes:
                 default: ''
+                type: string
+              objectClass:
+                default: user
                 type: string
               onBoarding2FA:
                 properties:
@@ -109,16 +158,52 @@ spec:
                   - platform
                   type: object
                 type: array
+              passwordWarning:
+                properties:
+                  enabled:
+                    type: boolean
+                  message:
+                    default: ''
+                    type: string
+                  thresholdDays:
+                    default: 5
+                    type: integer
+                type: object
+              port:
+                type: integer
+              providerCertificate:
+                default: ''
+                type: string
+              redirectUrl:
+                default: ''
+                type: string
+              sharedSecret:
+                default: null
+                type: string
+              skipX509ExternalChecks:
+                type: boolean
+              sslEnabled:
+                default: false
+                type: boolean
               tags:
                 items:
                   type: string
                 type: array
               type:
                 type: string
+              userLockoutDurationMinutes:
+                default: 1
+                type: integer
+              userLockoutThreshold:
+                default: 5
+                type: integer
               userScripts:
                 items:
                   type: string
                 type: array
+              usernameAttribute:
+                default: sAMAccountName
+                type: string
             required:
             - name
             - type

--- a/tests/resources/crd/v16/identityprovider.yaml
+++ b/tests/resources/crd/v16/identityprovider.yaml
@@ -18,12 +18,49 @@ spec:
         properties:
           spec:
             properties:
+              adminDistinguishedName:
+                default: ''
+                type: string
+              adminPassword:
+                default: null
+                type: string
               adminProvider:
                 default: false
                 type: boolean
+              audience:
+                default: ''
+                type: string
+              authenticationProtocol:
+                default: CHAP
+                type: string
+              baseDn:
+                default: ''
+                type: string
               blockLocalDnsRequests:
                 default: false
                 type: boolean
+              caCertificates:
+                items:
+                  type: string
+                type: array
+              certificateAttribute:
+                default: ''
+                type: string
+              certificatePriorities:
+                items:
+                  properties:
+                    type:
+                      default: Template
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - value
+                  type: object
+                type: array
+              certificateUserAttribute:
+                default: userPrincipalName
+                type: string
               claimMappings:
                 items:
                   properties:
@@ -42,6 +79,9 @@ spec:
                   - claimName
                   type: object
                 type: array
+              decryptionKey:
+                default: ''
+                type: string
               deviceLimitPerUser:
                 default: 100
                 type: integer
@@ -55,6 +95,12 @@ spec:
                 type: array
               enforceWindowsNetworkProfileAsDomain:
                 type: boolean
+              forceAuthn:
+                type: boolean
+              hostnames:
+                items:
+                  type: string
+                type: array
               inactivityTimeoutMinutes:
                 default: 0
                 type: integer
@@ -62,10 +108,25 @@ spec:
                 type: string
               ipPoolV6:
                 type: string
+              issuer:
+                default: ''
+                type: string
+              membershipBaseDn:
+                default: ''
+                type: string
+              membershipFilter:
+                default: (objectCategory=group)
+                type: string
+              minPasswordLength:
+                default: 0
+                type: integer
               name:
                 type: string
               notes:
                 default: ''
+                type: string
+              objectClass:
+                default: user
                 type: string
               onBoarding2FA:
                 properties:
@@ -109,16 +170,52 @@ spec:
                   - platform
                   type: object
                 type: array
+              passwordWarning:
+                properties:
+                  enabled:
+                    type: boolean
+                  message:
+                    default: ''
+                    type: string
+                  thresholdDays:
+                    default: 5
+                    type: integer
+                type: object
+              port:
+                type: integer
+              providerCertificate:
+                default: ''
+                type: string
+              redirectUrl:
+                default: ''
+                type: string
+              sharedSecret:
+                default: null
+                type: string
+              skipX509ExternalChecks:
+                type: boolean
+              sslEnabled:
+                default: false
+                type: boolean
               tags:
                 items:
                   type: string
                 type: array
               type:
                 type: string
+              userLockoutDurationMinutes:
+                default: 1
+                type: integer
+              userLockoutThreshold:
+                default: 5
+                type: integer
               userScripts:
                 items:
                   type: string
                 type: array
+              usernameAttribute:
+                default: sAMAccountName
+                type: string
             required:
             - name
             - type

--- a/tests/resources/test_entity.yaml
+++ b/tests/resources/test_entity.yaml
@@ -42,6 +42,8 @@ paths:
     $ref: '#/entity-dep-nested'
   /entity-dep-nested-nullable:
     $ref: '#/entity-dep-nested-nullable'
+  /entity-discriminator:
+    $ref: '#/entity-discriminator'
 
 entity-test0:
   get:
@@ -297,6 +299,21 @@ entity-dep-nested-nullable:
         application/json:
           schema:
             $ref: '#/definitions/EntityDepNestedNullable'
+
+entity-discriminator:
+  get:
+    responses:
+      '200':
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/EntityTestList'
+  post:
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/definitions/EntityDiscriminator'
 
 definitions:
   EntityTestList:
@@ -737,3 +754,47 @@ definitions:
                 timeout:
                   type: integer
                   default: 30
+  EntityDiscriminator:
+    allOf:
+      - type: object
+        discriminator:
+          propertyName: type
+          mapping:
+            DiscriminatorOne: '#/definitions/DiscriminatorOne'
+            DiscriminatorTwo: '#/definitions/DiscriminatorTwo'
+        required:
+          - type
+  EntityDiscriminatorSpec:
+    type: object
+    required:
+      - fieldOne
+    properties:
+      type:
+        type: string
+        enum:
+          - DiscriminatorOne
+          - DiscriminatorTwo
+      fieldOne:
+        type: string
+  DiscriminatorOne:
+    allOf:
+      - $ref: '#/definitions/EntityDiscriminatorSpec'
+      - type: object
+        required:
+          - discriminatorOneFieldOne
+        properties:
+          discriminatorOneFieldOne:
+            type: string
+          discriminatorOneFieldTwo:
+            type: string
+  DiscriminatorTwo:
+    allOf:
+      - $ref: '#/definitions/EntityDiscriminatorSpec'
+      - type: object
+        required:
+          - discriminatorTwoFieldTwo
+        properties:
+          discriminatorTwoFieldOne:
+            type: boolean
+          discriminatorTwoFieldTwo:
+            type: boolean

--- a/tests/resources/v12/identity_providers.yaml
+++ b/tests/resources/v12/identity_providers.yaml
@@ -28,7 +28,6 @@ spec:
   dnsSearchDomains: []
   dnsServers:
   - 127.123.123.1
-  id: 31e92c17-db36-45c6-8c96-e65fb2f57f3a
   ipPoolV4: f572b4ab-7963-4a90-9e5a-3bf033bfe2cc
   name: etewtew
   notes: 'wradsdf

--- a/tests/resources/v12/identity_providers.yaml
+++ b/tests/resources/v12/identity_providers.yaml
@@ -108,4 +108,4 @@ spec:
   onDemandClaimMappings: []
   tags:
   - builtin
-  type: IoTConnector
+  type: IotConnector

--- a/tests/resources/v12/identity_providers.yaml
+++ b/tests/resources/v12/identity_providers.yaml
@@ -4,6 +4,10 @@ metadata:
   name: etewtew
 spec:
   adminProvider: true
+  adminDistinguishedName: "foo"
+  hostnames:
+    - "foo.com"
+  port: 6443
   claimMappings:
   - attributeName: memberOf
     claimName: groups

--- a/tests/resources/v16/identity_provider.yml
+++ b/tests/resources/v16/identity_provider.yml
@@ -4,7 +4,6 @@ metadata:
   name: saml
 spec:
   type: Saml
-  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
   name: saml-example
   adminProvider: false
   deviceLimitPerUser: 100
@@ -55,7 +54,6 @@ metadata:
   name: radius
 spec:
   type: Radius
-  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
   name: radius-example
   adminProvider: false
   deviceLimitPerUser: 100
@@ -102,7 +100,6 @@ metadata:
   name: ldap
 spec:
   type: Ldap
-  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
   name: ldap-example
   adminProvider: false
   deviceLimitPerUser: 100
@@ -159,7 +156,6 @@ metadata:
   name: ldapcert
 spec:
   type: LdapCertificate
-  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
   name: ldapcert-example
   adminProvider: false
   deviceLimitPerUser: 100
@@ -224,7 +220,6 @@ metadata:
   name: localdatabase
 spec:
   type: LocalDatabase
-  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
   name: localdatabase-example
   adminProvider: false
   deviceLimitPerUser: 100
@@ -269,7 +264,6 @@ metadata:
   name: connector
 spec:
   type: Connector
-  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
   name: connector-example
   ipPoolV4: 1cbdf511-2da6-4762-8226-c68da51edcac
   ipPoolV6: 0abcaedb-13e8-4473-bbb1-2e25511b63ae

--- a/tests/resources/v16/identity_provider.yml
+++ b/tests/resources/v16/identity_provider.yml
@@ -1,0 +1,288 @@
+apiVersion: beta.appgate.com/v1
+kind: IdentityProvider
+metadata:
+  name: saml
+spec:
+  type: Saml
+  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
+  name: saml-example
+  adminProvider: false
+  deviceLimitPerUser: 100
+  onBoarding2FA:
+    mfaProviderId: 87582944-97ef-4239-825a-1dd1fe82b9d1
+    message: Please use your multi factor authentication device to on-board.
+    claimSuffix: onBoarding
+    alwaysRequired: true
+    deviceLimitPerUser: 0
+  inactivityTimeoutMinutes: 0
+  ipPoolV4: 1cbdf511-2da6-4762-8226-c68da51edcac
+  ipPoolV6: 0abcaedb-13e8-4473-bbb1-2e25511b63ae
+  dnsServers:
+    - 172.17.18.19
+    - 192.100.111.31
+  dnsSearchDomains:
+    - internal.company.com
+  enforceWindowsNetworkProfileAsDomain: true
+  blockLocalDnsRequests: false
+  claimMappings:
+    - attributeName: SAMAccountName
+      claimName: username
+      list: false
+      encrypt: false
+  onDemandClaimMappings:
+    - command: fileSize
+      claimName: antivirusRunning
+      parameters:
+        name: python3
+        path: "/usr/bin/python3"
+        args: "--list"
+      platform: desktop.windows.all
+  userScripts:
+    - 497f6eca-6276-4993-bfeb-53cbbbba6f08
+  redirectUrl: https://saml.company.com
+  issuer: http://adfs-test.company.com/adfs/services/trust
+  audience: Company Appgate SDP
+  providerCertificate: |-
+    -----BEGIN CERTIFICATE-----
+    adlkfaldfdfdfdkadkfkdlfj;kdajfkljdadff
+    -----END CERTIFICATE-----
+  decryptionKey: string
+  forceAuthn: true
+---
+apiVersion: beta.appgate.com/v1
+kind: IdentityProvider
+metadata:
+  name: radius
+spec:
+  type: Radius
+  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
+  name: radius-example
+  adminProvider: false
+  deviceLimitPerUser: 100
+  onBoarding2FA:
+    mfaProviderId: 87582944-97ef-4239-825a-1dd1fe82b9d1
+    message: Please use your multi factor authentication device to on-board.
+    claimSuffix: onBoarding
+    alwaysRequired: true
+    deviceLimitPerUser: 0
+  inactivityTimeoutMinutes: 0
+  ipPoolV4: 1cbdf511-2da6-4762-8226-c68da51edcac
+  ipPoolV6: 0abcaedb-13e8-4473-bbb1-2e25511b63ae
+  dnsServers:
+    - 172.17.18.19
+    - 192.100.111.31
+  dnsSearchDomains:
+    - internal.company.com
+  enforceWindowsNetworkProfileAsDomain: true
+  blockLocalDnsRequests: false
+  claimMappings:
+    - attributeName: SAMAccountName
+      claimName: username
+      list: false
+      encrypt: false
+  onDemandClaimMappings:
+    - command: fileSize
+      claimName: antivirusRunning
+      parameters:
+        name: python3
+        path: "/usr/bin/python3"
+        args: "--list"
+      platform: desktop.windows.all
+  userScripts:
+    - 497f6eca-6276-4993-bfeb-53cbbbba6f08
+  hostnames:
+    - radius.company.com
+  port: 1812
+  sharedSecret: string
+  authenticationProtocol: CHAP
+---
+apiVersion: beta.appgate.com/v1
+kind: IdentityProvider
+metadata:
+  name: ldap
+spec:
+  type: Ldap
+  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
+  name: ldap-example
+  adminProvider: false
+  deviceLimitPerUser: 100
+  onBoarding2FA:
+    mfaProviderId: 87582944-97ef-4239-825a-1dd1fe82b9d1
+    message: Please use your multi factor authentication device to on-board.
+    claimSuffix: onBoarding
+    alwaysRequired: true
+    deviceLimitPerUser: 0
+  inactivityTimeoutMinutes: 0
+  ipPoolV4: 1cbdf511-2da6-4762-8226-c68da51edcac
+  ipPoolV6: 0abcaedb-13e8-4473-bbb1-2e25511b63ae
+  dnsServers:
+    - 172.17.18.19
+    - 192.100.111.31
+  dnsSearchDomains:
+    - internal.company.com
+  enforceWindowsNetworkProfileAsDomain: true
+  blockLocalDnsRequests: false
+  claimMappings:
+    - attributeName: SAMAccountName
+      claimName: username
+      list: false
+      encrypt: false
+  onDemandClaimMappings:
+    - command: fileSize
+      claimName: antivirusRunning
+      parameters:
+        name: python3
+        path: "/usr/bin/python3"
+        args: "--list"
+      platform: desktop.windows.all
+  userScripts:
+    - 497f6eca-6276-4993-bfeb-53cbbbba6f08
+  hostnames:
+    - dc.ad.company.com
+  port: 389
+  sslEnabled: false
+  adminDistinguishedName: CN=admin,OU=Users,DC=company,DC=com
+  adminPassword: tSW3!QBv(rj{UuLY
+  baseDn: OU=Users,DC=company,DC=com
+  objectClass: user
+  usernameAttribute: sAMAccountName
+  membershipFilter: "(objectCategory=group)"
+  membershipBaseDn: OU=Groups,DC=company,DC=com
+  passwordWarning:
+    enabled: true
+    thresholdDays: 5
+    message: Your password is about to expire. Please change it.
+---
+apiVersion: beta.appgate.com/v1
+kind: IdentityProvider
+metadata:
+  name: ldapcert
+spec:
+  type: LdapCertificate
+  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
+  name: ldapcert-example
+  adminProvider: false
+  deviceLimitPerUser: 100
+  onBoarding2FA:
+    mfaProviderId: 87582944-97ef-4239-825a-1dd1fe82b9d1
+    message: Please use your multi factor authentication device to on-board.
+    claimSuffix: onBoarding
+    alwaysRequired: true
+    deviceLimitPerUser: 0
+  inactivityTimeoutMinutes: 0
+  ipPoolV4: 1cbdf511-2da6-4762-8226-c68da51edcac
+  ipPoolV6: 0abcaedb-13e8-4473-bbb1-2e25511b63ae
+  dnsServers:
+    - 172.17.18.19
+    - 192.100.111.31
+  dnsSearchDomains:
+    - internal.company.com
+  enforceWindowsNetworkProfileAsDomain: true
+  blockLocalDnsRequests: false
+  claimMappings:
+    - attributeName: SAMAccountName
+      claimName: username
+      list: false
+      encrypt: false
+  onDemandClaimMappings:
+    - command: fileSize
+      claimName: antivirusRunning
+      parameters:
+        name: python3
+        path: "/usr/bin/python3"
+        args: "--list"
+      platform: desktop.windows.all
+  userScripts:
+    - 497f6eca-6276-4993-bfeb-53cbbbba6f08
+  hostnames:
+    - dc.ad.company.com
+  port: 389
+  sslEnabled: false
+  adminDistinguishedName: CN=admin,OU=Users,DC=company,DC=com
+  adminPassword: tSW3!QBv(rj{UuLY
+  baseDn: OU=Users,DC=company,DC=com
+  objectClass: user
+  usernameAttribute: sAMAccountName
+  membershipFilter: "(objectCategory=group)"
+  membershipBaseDn: OU=Groups,DC=company,DC=com
+  passwordWarning:
+    enabled: true
+    thresholdDays: 5
+    message: Your password is about to expire. Please change it.
+  caCertificates:
+    - "-----BEGIN CERTIFICATE----- .... -----END CERTIFICATE-----"
+  certificateUserAttribute: userPrincipalName
+  certificateAttribute: string
+  skipX509ExternalChecks: true
+  certificatePriorities:
+    - type: Template
+      value: 1.3.6.1.4.1.311.21.8.3025710.4393146.2181807.13924342.9568199.8
+---
+apiVersion: beta.appgate.com/v1
+kind: IdentityProvider
+metadata:
+  name: localdatabase
+spec:
+  type: LocalDatabase
+  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
+  name: localdatabase-example
+  adminProvider: false
+  deviceLimitPerUser: 100
+  onBoarding2FA:
+    mfaProviderId: 87582944-97ef-4239-825a-1dd1fe82b9d1
+    message: Please use your multi factor authentication device to on-board.
+    claimSuffix: onBoarding
+    alwaysRequired: true
+    deviceLimitPerUser: 0
+  inactivityTimeoutMinutes: 0
+  ipPoolV4: 1cbdf511-2da6-4762-8226-c68da51edcac
+  ipPoolV6: 0abcaedb-13e8-4473-bbb1-2e25511b63ae
+  dnsServers:
+    - 172.17.18.19
+    - 192.100.111.31
+  dnsSearchDomains:
+    - internal.company.com
+  enforceWindowsNetworkProfileAsDomain: true
+  blockLocalDnsRequests: false
+  claimMappings:
+    - attributeName: SAMAccountName
+      claimName: username
+      list: false
+      encrypt: false
+  onDemandClaimMappings:
+    - command: fileSize
+      claimName: antivirusRunning
+      parameters:
+        name: python3
+        path: "/usr/bin/python3"
+        args: "--list"
+      platform: desktop.windows.all
+  userScripts:
+    - 497f6eca-6276-4993-bfeb-53cbbbba6f08
+  userLockoutThreshold: 5
+  userLockoutDurationMinutes: 1
+  minPasswordLength: 0
+---
+apiVersion: beta.appgate.com/v1
+kind: IdentityProvider
+metadata:
+  name: connector
+spec:
+  type: Connector
+  id: 4c07bc67-57ea-42dd-b702-c2d6c45419fc
+  name: connector-example
+  ipPoolV4: 1cbdf511-2da6-4762-8226-c68da51edcac
+  ipPoolV6: 0abcaedb-13e8-4473-bbb1-2e25511b63ae
+  claimMappings:
+    - attributeName: SAMAccountName
+      claimName: username
+      list: false
+      encrypt: false
+  onDemandClaimMappings:
+    - command: fileSize
+      claimName: antivirusRunning
+      parameters:
+        name: python3
+        path: "/usr/bin/python3"
+        args: "--list"
+      platform: desktop.windows.all

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -41,6 +41,20 @@ def test_load_entities_v12():
                 assert isinstance(APPGATE_LOADER.load(d["spec"], None, e), e)
 
 
+def test_load_entities_v16():
+    """
+    Real all yaml files in v16 and try to load them according to the kind
+    """
+    open_api = generate_api_spec(Path("api_specs/v16").parent / "v16")
+    entities = open_api.entities
+    for f in os.listdir("tests/resources/v16"):
+        with (Path("tests/resources/v16") / f).open("r") as f:
+            documents = list(yaml.safe_load_all(f))
+            for d in documents:
+                e = entities[d["kind"]].cls
+                assert isinstance(APPGATE_LOADER.load(d["spec"], None, e), e)
+
+
 def test_loader_deprecated_required():
     entities = load_test_open_api_spec(secrets_key=None, reload=True).entities
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -724,3 +724,57 @@ Hn+GmxZA
     # Just check that it's dumped properly
     assert e2_dumped["fieldOne"] == "foobar"
     assert e2_dumped["fieldTwo"]["validFrom"] == "2017-03-06T16:50:58.516Z"
+
+
+def test_discriminator_dump():
+    EntityDiscriminator = (
+        load_test_open_api_spec(secrets_key=None, reload=True)
+        .entities["EntityDiscriminator"]
+        .cls
+    )
+    appgate_metadata = {"uuid": "6a01c585-c192-475b-b86f-0e632add2769"}
+    data1 = {
+        "id": "foo",
+        "name": "bar",
+        "fieldOne": "hello",
+        "type": "DiscriminatorOne",
+        "discriminatorOneFieldOne": "hi",
+        "discriminatorOneFieldTwo": "bye",
+        "appgate_metadata": appgate_metadata,
+    }
+
+    e1 = K8S_LOADER.load(data1, None, EntityDiscriminator)
+    assert DIFF_DUMPER.dump(e1) == {
+        "fieldOne": "hello",
+        "discriminatorOneFieldOne": "hi",
+        "discriminatorOneFieldTwo": "bye",
+    }
+    assert APPGATE_DUMPER.dump(e1) == {
+        "type": "DiscriminatorOne",
+        "fieldOne": "hello",
+        "discriminatorOneFieldOne": "hi",
+        "discriminatorOneFieldTwo": "bye",
+    }
+
+    data2 = {
+        "id": "baz",
+        "name": "bat",
+        "fieldOne": "bye",
+        "type": "DiscriminatorTwo",
+        "discriminatorTwoFieldOne": True,
+        "discriminatorTwoFieldTwo": False,
+        "appgate_metadata": appgate_metadata,
+    }
+
+    e2 = K8S_LOADER.load(data2, None, EntityDiscriminator)
+    assert DIFF_DUMPER.dump(e2) == {
+        "fieldOne": "bye",
+        "discriminatorTwoFieldOne": True,
+        "discriminatorTwoFieldTwo": False,
+    }
+    assert APPGATE_DUMPER.dump(e2) == {
+        "type": "DiscriminatorTwo",
+        "fieldOne": "bye",
+        "discriminatorTwoFieldOne": True,
+        "discriminatorTwoFieldTwo": False,
+    }

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1758,3 +1758,51 @@ def test_compare_entities_updated_changed():
         '+    "updated": "2020-09-16T12:20:14.000Z"\n',
         " }",
     ]
+
+
+def test_discriminator_entities_updated():
+    EntityDiscriminator = (
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        .entities["EntityDiscriminator"]
+        .cls
+    )
+    data1 = {
+        "id": "foo",
+        "name": "bar",
+        "fieldOne": "hello",
+        "type": "DiscriminatorOne",
+        "discriminatorOneFieldOne": "hi",
+        "discriminatorOneFieldTwo": "bye",
+    }
+    data2 = {
+        "id": "hello",
+        "name": "world",
+        "fieldOne": "bye",
+        "type": "DiscriminatorOne",
+        "discriminatorOneFieldOne": "hihi",
+        "discriminatorOneFieldTwo": "byebye",
+    }
+    appgate_metadata = {
+        "generation": 1,
+        "latestGeneration": 1,
+        "creationTimestamp": "2020-09-10T10:20:14Z",
+        "modificationTimestamp": "2020-09-16T12:20:14Z",
+    }
+
+    e1 = EntityWrapper(K8S_LOADER.load(data1, appgate_metadata, EntityDiscriminator))
+    e2 = EntityWrapper(APPGATE_LOADER.load(data2, None, EntityDiscriminator))
+
+    diff = compute_diff(e2, e1)
+    assert diff == [
+        "--- \n",
+        "+++ \n",
+        "@@ -1,5 +1,5 @@\n",
+        " {\n",
+        '-    "fieldOne": "bye",\n',
+        '-    "discriminatorOneFieldOne": "hihi",\n',
+        '-    "discriminatorOneFieldTwo": "byebye"\n',
+        '+    "fieldOne": "hello",\n',
+        '+    "discriminatorOneFieldOne": "hi",\n',
+        '+    "discriminatorOneFieldTwo": "bye"\n',
+        " }",
+    ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,6 +38,7 @@ TestSpec = {
     "/entity-cert": "EntityCert",
     "/entity-dep-nested": "EntityDepNested7",
     "/entity-dep-nested-nullable": "EntityDepNestedNullable",
+    "/entity-discriminator": "EntityDiscriminator",
 }
 PEM_TEST = """-----BEGIN CERTIFICATE-----
 MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG


### PR DESCRIPTION
Add the ability to parse `discriminator` attributes to support IdentityProvider entity. 

When parsing an entity using discriminator, the parent entity (e.g. IdentityProvider) contains all attributes of its children and it keeps a mapping of resolved child entities (e.g. `IdentityProvider_Saml`, `IdentityProvider_Ldap`). User can continue to use the IdentityProvider CR to configure an identity provider on SDP. 

The validation for the fields are done by `DiscriminatorAttribMaker`. When you load a IdentityProvider with type=Saml, it makes sure that all fields required for type=Saml is present in the requested entity. 

