### PR TITLE
Convert CRD chart into application chart

### DIFF
--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for SDP Operator CRD
 # Library charts provide useful utilities or functions for the chart developer. They're included as
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
-type: library
+type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic


### PR DESCRIPTION
Library charts are not deployable. 