### PR TITLE
Allow tags as array in values.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ The following tools are required to install the SDP Operator
 | `sdp.operator.image.pullSecrets` | SDP operator pull secret        | `[]`                           |
 | `sdp.operator.logLevel`          | SDP Operator log level          | `info`                         |
 | `sdp.operator.timeout`           | SDP Operator event loop timeout | `30`                           |
-| `sdp.operator.builtinTags`       | SDP Operator builtin tags       | `builtin`                      |
+| `sdp.operator.builtinTags`       | SDP Operator builtin tags       | `["builtin"]`                  |
 | `sdp.operator.dryRun`            | SDP Operator dry-run mode       | `true`                         |
 | `sdp.operator.cleanup`           | SDP Operator cleanup mode       | `false`                        |
 | `sdp.operator.twoWaySync`        | SDP Operator two-way-sync mode  | `true`                         |
 | `sdp.operator.sslNoVerify`       | SDP Operator ssl-no-verify mode | `false`                        |
-| `sdp.operator.targetTags`        | SDP Operator target tags        | `""`                           |
-| `sdp.operator.excludeTags`       | SDP Operator exclude tags       | `""`                           |
+| `sdp.operator.targetTags`        | SDP Operator target tags        | `[]`                           |
+| `sdp.operator.excludeTags`       | SDP Operator exclude tags       | `[]`                           |
 | `sdp.operator.caCert`            | SDP Operator host CA cert       | `""`                           |
 | `sdp.operator.fernetKey`         | SDP Operator Fernet Key         | `""`                           |
 | `sdp.operator.configMapMt`       | SDP Operator metadata configmap | `""`                           |

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic
 # Versioning (https://semver.org/).
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/operator/Chart.yaml
+++ b/k8s/operator/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/operator/templates/deployment.yaml
+++ b/k8s/operator/templates/deployment.yaml
@@ -51,15 +51,15 @@ spec:
               value: "{{ .Values.sdp.operator.timeout }}"
             {{- with .Values.sdp.operator.targetTags }}
             - name: APPGATE_OPERATOR_TARGET_TAGS
-              value: "{{ . }}"
+              value: "{{ join "," . }}"
             {{- end }}
             {{- with .Values.sdp.operator.excludeTags }}
             - name: APPGATE_OPERATOR_EXCLUDE_TAGS
-              value: "{{ . }}"
+              value: "{{ join "," . }}"
             {{- end }}
             {{- with .Values.sdp.operator.builtinTags }}
             - name: APPGATE_OPERATOR_BUILTIN_TAGS
-              value: "{{ . }}"
+              value: "{{ join "," . }}"
             {{- end }}
             - name: APPGATE_OPERATOR_DRY_RUN
               value: "{{ .Values.sdp.operator.dryRun }}"

--- a/k8s/operator/templates/deployment.yaml
+++ b/k8s/operator/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
               value: "{{ . }}"
             {{- end }}
             {{- with .Values.sdp.operator.excludeTags }}
-            - name: APPGATE_OPERATOR_EXCLUDE_TAG
+            - name: APPGATE_OPERATOR_EXCLUDE_TAGS
               value: "{{ . }}"
             {{- end }}
             {{- with .Values.sdp.operator.builtinTags }}

--- a/k8s/operator/values.schema.json
+++ b/k8s/operator/values.schema.json
@@ -52,7 +52,10 @@
               "type": "number"
             },
             "builtinTags": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "dryRun": {
               "type": "boolean"
@@ -64,10 +67,16 @@
               "type": "boolean"
             },
             "targetTags": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "excludeTags": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "fernetKey": {
               "type": "string"

--- a/k8s/operator/values.yaml
+++ b/k8s/operator/values.yaml
@@ -36,13 +36,14 @@ sdp:
     ## @param sdp.operator.configMapMt SDP Operator metadata configmap
     logLevel: info
     timeout: 30
-    builtinTags: builtin
+    builtinTags:
+      - builtin
     dryRun: true
     twoWaySync: true
     cleanup: false
     sslNoVerify: false
-    targetTags: ""
-    excludeTags: ""
+    targetTags: []
+    excludeTags: []
     fernetKey: ""
     caCert: ""
     configMapMt: ""


### PR DESCRIPTION
Pass tag as array in values.yaml and join them into a comma-separated string before passing it to env

The following yaml 
```
    targetTags:
      - targetFoo
    excludeTags:
      - excludeFoo
      - excludeBar
    builtinTags:
      - builtin
``` 
will be passed to the environment as 
```
root@sdp-operator-65c56c689-q4n2g:~# env | grep TAGS
APPGATE_OPERATOR_BUILTIN_TAGS=builtin
APPGATE_OPERATOR_TARGET_TAGS=targetFoo
APPGATE_OPERATOR_EXCLUDE_TAGS=excludeFoo,excludeBar
```