### PR TITLE
Update python packages to their latest available

### DIFF
--- a/appgate/attrs.py
+++ b/appgate/attrs.py
@@ -1,4 +1,5 @@
 import datetime
+import dateutil
 from typing import Dict, Any, List, Callable, Optional, Iterable, Union, Type
 
 from typedload import dataloader
@@ -68,7 +69,7 @@ def is_datetime_dumper(value: Any) -> bool:
 
 def parse_datetime(value) -> datetime.datetime:
     try:
-        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dateutil.parser.isoparse(value.replace("Z", "+00:00"))
     except Exception as e:
         raise TypedloadException(f"Unable to parse {value} as a datetime: {e}")
 

--- a/appgate/attrs.py
+++ b/appgate/attrs.py
@@ -1,5 +1,5 @@
 import datetime
-import dateutil
+from dateutil import parser
 from typing import Dict, Any, List, Callable, Optional, Iterable, Union, Type
 
 from typedload import dataloader
@@ -69,7 +69,8 @@ def is_datetime_dumper(value: Any) -> bool:
 
 def parse_datetime(value) -> datetime.datetime:
     try:
-        return dateutil.parser.isoparse(value.replace("Z", "+00:00"))
+        # dateutil.fromisofromat cannot handle string that contains 6+ sub-second digits
+        return parser.isoparse(value.replace("Z", "+00:00"))
     except Exception as e:
         raise TypedloadException(f"Unable to parse {value} as a datetime: {e}")
 

--- a/k8s/crd/templates/v17.yaml
+++ b/k8s/crd/templates/v17.yaml
@@ -116,7 +116,6 @@ spec:
                   type: string
                 type: array
               tamperProofing:
-                default: true
                 type: boolean
               trustedNetworkCheck:
                 properties:

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -4,3 +4,4 @@ pytest==6.2.4
 black==22.3.0
 # type stubs
 types-PyYAML==6.0.1
+types-python-dateutil==2.8.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ async-timeout==4.0.2
 attrs==22.1.0
 cachetools==5.2.0
 certifi==2022.9.24
-cffi==1.15.0
+cffi==1.15.1
 charset-normalizer==2.0.9
 cryptography==36.0.1
 frozenlist==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ six==1.16.0
 typedload==2.7
 urllib3==1.26.12
 websocket-client==1.4.1
-yarl==1.7.2
+yarl==1.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ frozenlist==1.3.1
 google-auth==2.11.1
 idna==3.3
 kubernetes==24.2.0
-multidict==5.2.0
+multidict==6.0.2
 oauthlib==3.1.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiosignal==1.2.0
 apischema==0.17.5
 async-timeout==4.0.2
 attrs==22.1.0
-cachetools==4.2.4
+cachetools==5.2.0
 certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ cffi==1.15.1
 charset-normalizer==2.1.1
 cryptography==38.0.1
 frozenlist==1.3.1
-google-auth==2.3.3
+google-auth==2.11.1
 idna==3.3
 kubernetes==21.7.0
 multidict==5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp==3.8.3
 aiosignal==1.2.0
-apischema==0.17
+apischema==0.17.5
 async-timeout==4.0.2
 attrs==21.4.0
 cachetools==4.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ google-auth==2.11.1
 idna==3.3
 kubernetes==24.2.0
 multidict==6.0.2
-oauthlib==3.1.1
+oauthlib==3.2.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ apischema==0.17.5
 async-timeout==4.0.2
 attrs==22.1.0
 cachetools==5.2.0
-certifi==2021.10.8
+certifi==2022.9.24
 cffi==1.15.0
 charset-normalizer==2.0.9
 cryptography==36.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.8.3
 aiosignal==1.2.0
 apischema==0.17.5
 async-timeout==4.0.2
-attrs==21.4.0
+attrs==22.1.0
 cachetools==4.2.4
 certifi==2021.10.8
 cffi==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ attrs==22.1.0
 cachetools==5.2.0
 certifi==2022.9.24
 cffi==1.15.1
-charset-normalizer==2.0.9
+charset-normalizer==2.1.1
 cryptography==36.0.1
 frozenlist==1.2.0
 google-auth==2.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,5 @@ rsa==4.9
 six==1.16.0
 typedload==2.7
 urllib3==1.26.12
-websocket-client==1.2.3
+websocket-client==1.4.1
 yarl==1.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,5 @@ rsa==4.9
 six==1.16.0
 typedload==2.7
 urllib3==1.26.12
-websocket-client==1.4.1
-yarl==1.8.1
+websocket-client==1.2.3
+yarl==1.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ certifi==2022.9.24
 cffi==1.15.1
 charset-normalizer==2.1.1
 cryptography==38.0.1
-frozenlist==1.2.0
+frozenlist==1.3.1
 google-auth==2.3.3
 idna==3.3
 kubernetes==21.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cachetools==5.2.0
 certifi==2022.9.24
 cffi==1.15.1
 charset-normalizer==2.1.1
-cryptography==36.0.1
+cryptography==38.0.1
 frozenlist==1.2.0
 google-auth==2.3.3
 idna==3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pyasn1-modules==0.2.8
 pycparser==2.21
 python-dateutil==2.8.2
 PyYAML==6.0
-requests==2.27.0
+requests==2.28.1
 requests-oauthlib==1.3.0
 rsa==4.8
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.1
+aiohttp==3.8.3
 aiosignal==1.2.0
 apischema==0.17
 async-timeout==4.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,9 @@ python-dateutil==2.8.2
 PyYAML==6.0
 requests==2.28.1
 requests-oauthlib==1.3.1
-rsa==4.8
+rsa==4.9
 six==1.16.0
 typedload==2.7
-urllib3==1.26.7
-websocket-client==1.2.3
-yarl==1.7.2
+urllib3==1.26.12
+websocket-client==1.4.1
+yarl==1.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cryptography==38.0.1
 frozenlist==1.3.1
 google-auth==2.11.1
 idna==3.3
-kubernetes==21.7.0
+kubernetes==24.2.0
 multidict==5.2.0
 oauthlib==3.1.1
 pyasn1==0.4.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pycparser==2.21
 python-dateutil==2.8.2
 PyYAML==6.0
 requests==2.28.1
-requests-oauthlib==1.3.0
+requests-oauthlib==1.3.1
 rsa==4.8
 six==1.16.0
 typedload==2.7

--- a/tests/resources/crd/v17/policy.yaml
+++ b/tests/resources/crd/v17/policy.yaml
@@ -115,7 +115,6 @@ spec:
                   type: string
                 type: array
               tamperProofing:
-                default: true
                 type: boolean
               trustedNetworkCheck:
                 properties:


### PR DESCRIPTION
* Update packages to their latest available
* I skipped updating typedload to 2.18 because I hit an issue while testing. Will take a look at when I have more time. 

Tested the sdp-operator deployment on my local cluster