### PR TITLE
Dump API specs into /root instead of /root/api_specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PYTHON3=python3.10
 
 all: api_specs lint test
 
+.PHONY: api_specs
 api_specs:
 	@./bin/get-open-spec.sh
 	@./bin/unzip-open-spec.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN python3 -m venv /root/venv && \
     rm -r /root/.cache && rm /root/requirements.txt
 
 COPY appgate /root/appgate/
-COPY api_specs /root/appgate/api_specs/
+COPY api_specs /root/api_specs
 COPY docker/assets/run.sh /root/run.sh
 RUN chmod +x /root/run.sh
 WORKDIR /root

--- a/k8s/operator/templates/deployment.yaml
+++ b/k8s/operator/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
           imagePullPolicy: {{ .Values.sdp.operator.image.pullPolicy }}
           args:
             - --spec-directory
-            - "/root/appgate/api_specs/{{ required "A valid .Values.sdp.operator.version entry is required!" .Values.sdp.operator.version }}"
+            - "/root/api_specs/{{ required "A valid .Values.sdp.operator.version entry is required!" .Values.sdp.operator.version }}"
             - run
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
When you directly run the SDP operator image, (e.g. `docker run sdp-operator api-info`), it hits a FileNotFound error when looking for the API specification. Fix the location of the API specs in the Dockerfile and adjust the helm chart. 