### PR TITLE
Update certifi to 2022.12.07 version for CVE-2022-23491

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@
 #
 aiohttp==3.8.3
     # via -r requirements.in
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via aiohttp
-apischema==0.17.5
+apischema==0.18.0
     # via -r requirements.in
 async-timeout==4.0.2
     # via aiohttp
@@ -18,7 +18,7 @@ attrs==22.1.0
     #   aiohttp
 cachetools==5.2.0
     # via google-auth
-certifi==2022.9.24
+certifi==2022.12.7
     # via
     #   kubernetes
     #   requests
@@ -28,13 +28,13 @@ charset-normalizer==2.1.1
     # via
     #   aiohttp
     #   requests
-cryptography==38.0.3
+cryptography==38.0.4
     # via -r requirements.in
-frozenlist==1.3.1
+frozenlist==1.3.3
     # via
     #   aiohttp
     #   aiosignal
-google-auth==2.14.1
+google-auth==2.15.0
     # via kubernetes
 idna==3.4
     # via
@@ -42,7 +42,7 @@ idna==3.4
     #   yarl
 kubernetes==25.3.0
     # via -r requirements.in
-multidict==6.0.2
+multidict==6.0.3
     # via
     #   aiohttp
     #   yarl
@@ -75,13 +75,13 @@ six==1.16.0
     #   python-dateutil
 typedload==2.12
     # via -r requirements.in
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   kubernetes
     #   requests
 websocket-client==1.4.2
     # via kubernetes
-yarl==1.8.1
+yarl==1.8.2
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Run `pip-compile` to update some packages, particular `certifi` for CVE-2022-23491