### PR TITLE
Change domain formatting to <version>.sdp.appgate.com

### DIFF
--- a/appgate/__main__.py
+++ b/appgate/__main__.py
@@ -219,7 +219,7 @@ async def run_k8s(args: OperatorArguments) -> None:
         start_entity_loop(
             ctx=ctx,
             queue=events_queue,
-            crd=entity_names(e.cls, {}, f"v{ctx.api_spec.api_version}")[2],
+            crd=entity_names(e.cls, {})[2],
             singleton=e.singleton,
             entity_type=e.cls,
             k8s_configmap_client=k8s_configmap_client,

--- a/appgate/appgate.py
+++ b/appgate/appgate.py
@@ -114,7 +114,7 @@ def run_entity_loop(
     log.info(f"[{crd}/{namespace}] Loop for {crd}/{namespace} started")
     watcher = Watch().stream(
         get_crds().list_namespaced_custom_object,
-        K8S_APPGATE_DOMAIN,
+        f"v{ctx.api_spec.api_version}.{K8S_APPGATE_DOMAIN}",
         K8S_APPGATE_VERSION,
         namespace,
         crd,

--- a/appgate/openapi/openapi.py
+++ b/appgate/openapi/openapi.py
@@ -162,9 +162,7 @@ def generate_crd(entity: Type, short_names: Dict[str, str], api_version: str) ->
 
     settings.default_object_fields = attrs_fields
 
-    name, singular_name, plural_name, short_name = entity_names(
-        entity, short_names
-    )
+    name, singular_name, plural_name, short_name = entity_names(entity, short_names)
     schema = deserialization_schema(entity)
 
     def replace_nullable_type(obj: dict) -> dict:

--- a/appgate/openapi/openapi.py
+++ b/appgate/openapi/openapi.py
@@ -102,7 +102,7 @@ def parse_files(
 
 
 def entity_names(
-    entity: type, short_names: Dict[str, str], api_version: str
+    entity: type, short_names: Dict[str, str]
 ) -> Tuple[str, str, str, str]:
     name = entity.__name__
     short_name = name[0:3].lower()
@@ -123,12 +123,6 @@ def entity_names(
         plural_name = f"{singular_name[:-1]}ies"
     else:
         plural_name = f"{singular_name}s"
-
-    if api_version:
-        name = f"{name}-{api_version}"
-        singular_name = f"{singular_name}-{api_version}"
-        plural_name = f"{plural_name}-{api_version}"
-        short_name = f"{short_name}-{api_version}"
 
     return name, singular_name, plural_name, short_name
 
@@ -169,7 +163,7 @@ def generate_crd(entity: Type, short_names: Dict[str, str], api_version: str) ->
     settings.default_object_fields = attrs_fields
 
     name, singular_name, plural_name, short_name = entity_names(
-        entity, short_names, api_version
+        entity, short_names
     )
     schema = deserialization_schema(entity)
 
@@ -241,14 +235,16 @@ def generate_crd(entity: Type, short_names: Dict[str, str], api_version: str) ->
 
     schema = replace_underscore(schema)
 
+    domain = f"{api_version}.{K8S_APPGATE_DOMAIN}"
+
     crd = {
         "apiVersion": K8S_API_VERSION,
         "kind": K8S_CRD_KIND,
         "metadata": {
-            "name": f"{plural_name}.{K8S_APPGATE_DOMAIN}",
+            "name": f"{plural_name}.{domain}",
         },
         "spec": {
-            "group": K8S_APPGATE_DOMAIN,
+            "group": domain,
             "versions": [
                 {
                     "name": K8S_APPGATE_VERSION,

--- a/appgate/openapi/types.py
+++ b/appgate/openapi/types.py
@@ -47,7 +47,7 @@ SPEC_ENTITIES = {
     "/service-users": "ServiceUser",
 }
 
-K8S_APPGATE_DOMAIN = "beta.appgate.com"
+K8S_APPGATE_DOMAIN = "sdp.appgate.com"
 K8S_APPGATE_VERSION = "v1"
 ENTITY_METADATA_ATTRIB_NAME = "_entity_metadata"
 APPGATE_METADATA_ATTRIB_NAME = "appgate_metadata"

--- a/k8s/crd/templates/v14.yaml
+++ b/k8s/crd/templates/v14.yaml
@@ -2,15 +2,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: policies-v14.beta.appgate.com
+  name: policies.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: Policy-v14
-    plural: policies-v14
+    kind: Policy
+    plural: policies
     shortNames:
-    - pol-v14
-    singular: policy-v14
+    - pol
+    singular: policy
   scope: Namespaced
   versions:
   - name: v1
@@ -87,15 +87,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: conditions-v14.beta.appgate.com
+  name: conditions.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: Condition-v14
-    plural: conditions-v14
+    kind: Condition
+    plural: conditions
     shortNames:
-    - con-v14
-    singular: condition-v14
+    - con
+    singular: condition
   scope: Namespaced
   versions:
   - name: v1
@@ -150,15 +150,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlements-v14.beta.appgate.com
+  name: entitlements.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: Entitlement-v14
-    plural: entitlements-v14
+    kind: Entitlement
+    plural: entitlements
     shortNames:
-    - ent-v14
-    singular: entitlement-v14
+    - ent
+    singular: entitlement
   scope: Namespaced
   versions:
   - name: v1
@@ -254,15 +254,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ringfencerules-v14.beta.appgate.com
+  name: ringfencerules.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: RingfenceRule-v14
-    plural: ringfencerules-v14
+    kind: RingfenceRule
+    plural: ringfencerules
     shortNames:
-    - rin-v14
-    singular: ringfencerule-v14
+    - rin
+    singular: ringfencerule
   scope: Namespaced
   versions:
   - name: v1
@@ -317,15 +317,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliances-v14.beta.appgate.com
+  name: appliances.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: Appliance-v14
-    plural: appliances-v14
+    kind: Appliance
+    plural: appliances
     shortNames:
-    - app-v14
-    singular: appliance-v14
+    - app
+    singular: appliance
   scope: Namespaced
   versions:
   - name: v1
@@ -902,15 +902,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: sites-v14.beta.appgate.com
+  name: sites.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: Site-v14
-    plural: sites-v14
+    kind: Site
+    plural: sites
     shortNames:
-    - sit-v14
-    singular: site-v14
+    - sit
+    singular: site
   scope: Namespaced
   versions:
   - name: v1
@@ -1156,15 +1156,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ippools-v14.beta.appgate.com
+  name: ippools.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: IpPool-v14
-    plural: ippools-v14
+    kind: IpPool
+    plural: ippools
     shortNames:
-    - ipp-v14
-    singular: ippool-v14
+    - ipp
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1
@@ -1212,15 +1212,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: identityproviders-v14.beta.appgate.com
+  name: identityproviders.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: IdentityProvider-v14
-    plural: identityproviders-v14
+    kind: IdentityProvider
+    plural: identityproviders
     shortNames:
-    - ide-v14
-    singular: identityprovider-v14
+    - ide
+    singular: identityprovider
   scope: Namespaced
   versions:
   - name: v1
@@ -1424,15 +1424,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: localusers-v14.beta.appgate.com
+  name: localusers.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: LocalUser-v14
-    plural: localusers-v14
+    kind: LocalUser
+    plural: localusers
     shortNames:
-    - loc-v14
-    singular: localuser-v14
+    - loc
+    singular: localuser
   scope: Namespaced
   versions:
   - name: v1
@@ -1480,15 +1480,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: administrativeroles-v14.beta.appgate.com
+  name: administrativeroles.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: AdministrativeRole-v14
-    plural: administrativeroles-v14
+    kind: AdministrativeRole
+    plural: administrativeroles
     shortNames:
-    - adm-v14
-    singular: administrativerole-v14
+    - adm
+    singular: administrativerole
   scope: Namespaced
   versions:
   - name: v1
@@ -1545,15 +1545,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: mfaproviders-v14.beta.appgate.com
+  name: mfaproviders.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: MfaProvider-v14
-    plural: mfaproviders-v14
+    kind: MfaProvider
+    plural: mfaproviders
     shortNames:
-    - mfa-v14
-    singular: mfaprovider-v14
+    - mfa
+    singular: mfaprovider
   scope: Namespaced
   versions:
   - name: v1
@@ -1610,15 +1610,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: adminmfasettingss-v14.beta.appgate.com
+  name: adminmfasettingss.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: AdminMfaSettings-v14
-    plural: adminmfasettingss-v14
+    kind: AdminMfaSettings
+    plural: adminmfasettingss
     shortNames:
-    - adi-v14
-    singular: adminmfasettings-v14
+    - adi
+    singular: adminmfasettings
   scope: Namespaced
   versions:
   - name: v1
@@ -1641,15 +1641,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: trustedcertificates-v14.beta.appgate.com
+  name: trustedcertificates.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: TrustedCertificate-v14
-    plural: trustedcertificates-v14
+    kind: TrustedCertificate
+    plural: trustedcertificates
     shortNames:
-    - tru-v14
-    singular: trustedcertificate-v14
+    - tru
+    singular: trustedcertificate
   scope: Namespaced
   versions:
   - name: v1
@@ -1680,15 +1680,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: criteriascriptss-v14.beta.appgate.com
+  name: criteriascriptss.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: CriteriaScripts-v14
-    plural: criteriascriptss-v14
+    kind: CriteriaScripts
+    plural: criteriascriptss
     shortNames:
-    - cri-v14
-    singular: criteriascripts-v14
+    - cri
+    singular: criteriascripts
   scope: Namespaced
   versions:
   - name: v1
@@ -1719,15 +1719,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: devicescripts-v14.beta.appgate.com
+  name: devicescripts.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: DeviceScript-v14
-    plural: devicescripts-v14
+    kind: DeviceScript
+    plural: devicescripts
     shortNames:
-    - dev-v14
-    singular: devicescript-v14
+    - dev
+    singular: devicescript
   scope: Namespaced
   versions:
   - name: v1
@@ -1761,15 +1761,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlementscripts-v14.beta.appgate.com
+  name: entitlementscripts.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: EntitlementScript-v14
-    plural: entitlementscripts-v14
+    kind: EntitlementScript
+    plural: entitlementscripts
     shortNames:
-    - enr-v14
-    singular: entitlementscript-v14
+    - enr
+    singular: entitlementscript
   scope: Namespaced
   versions:
   - name: v1
@@ -1803,15 +1803,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliancecustomizations-v14.beta.appgate.com
+  name: appliancecustomizations.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: ApplianceCustomization-v14
-    plural: appliancecustomizations-v14
+    kind: ApplianceCustomization
+    plural: appliancecustomizations
     shortNames:
-    - apt-v14
-    singular: appliancecustomization-v14
+    - apt
+    singular: appliancecustomization
   scope: Namespaced
   versions:
   - name: v1
@@ -1842,15 +1842,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: globalsettingss-v14.beta.appgate.com
+  name: globalsettingss.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: GlobalSettings-v14
-    plural: globalsettingss-v14
+    kind: GlobalSettings
+    plural: globalsettingss
     shortNames:
-    - glo-v14
-    singular: globalsettings-v14
+    - glo
+    singular: globalsettings
   scope: Namespaced
   versions:
   - name: v1
@@ -1902,15 +1902,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clientconnections-v14.beta.appgate.com
+  name: clientconnections.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: ClientConnection-v14
-    plural: clientconnections-v14
+    kind: ClientConnection
+    plural: clientconnections
     shortNames:
-    - cli-v14
-    singular: clientconnection-v14
+    - cli
+    singular: clientconnection
   scope: Namespaced
   versions:
   - name: v1

--- a/k8s/crd/templates/v15.yaml
+++ b/k8s/crd/templates/v15.yaml
@@ -2,15 +2,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: policies-v15.beta.appgate.com
+  name: policies.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: Policy-v15
-    plural: policies-v15
+    kind: Policy
+    plural: policies
     shortNames:
-    - pol-v15
-    singular: policy-v15
+    - pol
+    singular: policy
   scope: Namespaced
   versions:
   - name: v1
@@ -122,15 +122,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: conditions-v15.beta.appgate.com
+  name: conditions.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: Condition-v15
-    plural: conditions-v15
+    kind: Condition
+    plural: conditions
     shortNames:
-    - con-v15
-    singular: condition-v15
+    - con
+    singular: condition
   scope: Namespaced
   versions:
   - name: v1
@@ -185,15 +185,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlements-v15.beta.appgate.com
+  name: entitlements.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: Entitlement-v15
-    plural: entitlements-v15
+    kind: Entitlement
+    plural: entitlements
     shortNames:
-    - ent-v15
-    singular: entitlement-v15
+    - ent
+    singular: entitlement
   scope: Namespaced
   versions:
   - name: v1
@@ -289,15 +289,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ringfencerules-v15.beta.appgate.com
+  name: ringfencerules.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: RingfenceRule-v15
-    plural: ringfencerules-v15
+    kind: RingfenceRule
+    plural: ringfencerules
     shortNames:
-    - rin-v15
-    singular: ringfencerule-v15
+    - rin
+    singular: ringfencerule
   scope: Namespaced
   versions:
   - name: v1
@@ -352,15 +352,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliances-v15.beta.appgate.com
+  name: appliances.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: Appliance-v15
-    plural: appliances-v15
+    kind: Appliance
+    plural: appliances
     shortNames:
-    - app-v15
-    singular: appliance-v15
+    - app
+    singular: appliance
   scope: Namespaced
   versions:
   - name: v1
@@ -999,15 +999,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: sites-v15.beta.appgate.com
+  name: sites.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: Site-v15
-    plural: sites-v15
+    kind: Site
+    plural: sites
     shortNames:
-    - sit-v15
-    singular: site-v15
+    - sit
+    singular: site
   scope: Namespaced
   versions:
   - name: v1
@@ -1264,15 +1264,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ippools-v15.beta.appgate.com
+  name: ippools.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: IpPool-v15
-    plural: ippools-v15
+    kind: IpPool
+    plural: ippools
     shortNames:
-    - ipp-v15
-    singular: ippool-v15
+    - ipp
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1
@@ -1320,15 +1320,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: identityproviders-v15.beta.appgate.com
+  name: identityproviders.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: IdentityProvider-v15
-    plural: identityproviders-v15
+    kind: IdentityProvider
+    plural: identityproviders
     shortNames:
-    - ide-v15
-    singular: identityprovider-v15
+    - ide
+    singular: identityprovider
   scope: Namespaced
   versions:
   - name: v1
@@ -1534,15 +1534,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: localusers-v15.beta.appgate.com
+  name: localusers.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: LocalUser-v15
-    plural: localusers-v15
+    kind: LocalUser
+    plural: localusers
     shortNames:
-    - loc-v15
-    singular: localuser-v15
+    - loc
+    singular: localuser
   scope: Namespaced
   versions:
   - name: v1
@@ -1590,15 +1590,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: administrativeroles-v15.beta.appgate.com
+  name: administrativeroles.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: AdministrativeRole-v15
-    plural: administrativeroles-v15
+    kind: AdministrativeRole
+    plural: administrativeroles
     shortNames:
-    - adm-v15
-    singular: administrativerole-v15
+    - adm
+    singular: administrativerole
   scope: Namespaced
   versions:
   - name: v1
@@ -1655,15 +1655,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: mfaproviders-v15.beta.appgate.com
+  name: mfaproviders.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: MfaProvider-v15
-    plural: mfaproviders-v15
+    kind: MfaProvider
+    plural: mfaproviders
     shortNames:
-    - mfa-v15
-    singular: mfaprovider-v15
+    - mfa
+    singular: mfaprovider
   scope: Namespaced
   versions:
   - name: v1
@@ -1720,15 +1720,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: adminmfasettingss-v15.beta.appgate.com
+  name: adminmfasettingss.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: AdminMfaSettings-v15
-    plural: adminmfasettingss-v15
+    kind: AdminMfaSettings
+    plural: adminmfasettingss
     shortNames:
-    - adi-v15
-    singular: adminmfasettings-v15
+    - adi
+    singular: adminmfasettings
   scope: Namespaced
   versions:
   - name: v1
@@ -1751,15 +1751,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: trustedcertificates-v15.beta.appgate.com
+  name: trustedcertificates.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: TrustedCertificate-v15
-    plural: trustedcertificates-v15
+    kind: TrustedCertificate
+    plural: trustedcertificates
     shortNames:
-    - tru-v15
-    singular: trustedcertificate-v15
+    - tru
+    singular: trustedcertificate
   scope: Namespaced
   versions:
   - name: v1
@@ -1790,15 +1790,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: criteriascriptss-v15.beta.appgate.com
+  name: criteriascriptss.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: CriteriaScripts-v15
-    plural: criteriascriptss-v15
+    kind: CriteriaScripts
+    plural: criteriascriptss
     shortNames:
-    - cri-v15
-    singular: criteriascripts-v15
+    - cri
+    singular: criteriascripts
   scope: Namespaced
   versions:
   - name: v1
@@ -1829,15 +1829,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: devicescripts-v15.beta.appgate.com
+  name: devicescripts.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: DeviceScript-v15
-    plural: devicescripts-v15
+    kind: DeviceScript
+    plural: devicescripts
     shortNames:
-    - dev-v15
-    singular: devicescript-v15
+    - dev
+    singular: devicescript
   scope: Namespaced
   versions:
   - name: v1
@@ -1871,15 +1871,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlementscripts-v15.beta.appgate.com
+  name: entitlementscripts.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: EntitlementScript-v15
-    plural: entitlementscripts-v15
+    kind: EntitlementScript
+    plural: entitlementscripts
     shortNames:
-    - enr-v15
-    singular: entitlementscript-v15
+    - enr
+    singular: entitlementscript
   scope: Namespaced
   versions:
   - name: v1
@@ -1913,15 +1913,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliancecustomizations-v15.beta.appgate.com
+  name: appliancecustomizations.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: ApplianceCustomization-v15
-    plural: appliancecustomizations-v15
+    kind: ApplianceCustomization
+    plural: appliancecustomizations
     shortNames:
-    - apt-v15
-    singular: appliancecustomization-v15
+    - apt
+    singular: appliancecustomization
   scope: Namespaced
   versions:
   - name: v1
@@ -1952,15 +1952,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: globalsettingss-v15.beta.appgate.com
+  name: globalsettingss.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: GlobalSettings-v15
-    plural: globalsettingss-v15
+    kind: GlobalSettings
+    plural: globalsettingss
     shortNames:
-    - glo-v15
-    singular: globalsettings-v15
+    - glo
+    singular: globalsettings
   scope: Namespaced
   versions:
   - name: v1
@@ -2013,15 +2013,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clientconnections-v15.beta.appgate.com
+  name: clientconnections.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: ClientConnection-v15
-    plural: clientconnections-v15
+    kind: ClientConnection
+    plural: clientconnections
     shortNames:
-    - cli-v15
-    singular: clientconnection-v15
+    - cli
+    singular: clientconnection
   scope: Namespaced
   versions:
   - name: v1

--- a/k8s/crd/templates/v16.yaml
+++ b/k8s/crd/templates/v16.yaml
@@ -2,15 +2,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: policies-v16.beta.appgate.com
+  name: policies.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: Policy-v16
-    plural: policies-v16
+    kind: Policy
+    plural: policies
     shortNames:
-    - pol-v16
-    singular: policy-v16
+    - pol
+    singular: policy
   scope: Namespaced
   versions:
   - name: v1
@@ -141,15 +141,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: conditions-v16.beta.appgate.com
+  name: conditions.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: Condition-v16
-    plural: conditions-v16
+    kind: Condition
+    plural: conditions
     shortNames:
-    - con-v16
-    singular: condition-v16
+    - con
+    singular: condition
   scope: Namespaced
   versions:
   - name: v1
@@ -204,15 +204,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlements-v16.beta.appgate.com
+  name: entitlements.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: Entitlement-v16
-    plural: entitlements-v16
+    kind: Entitlement
+    plural: entitlements
     shortNames:
-    - ent-v16
-    singular: entitlement-v16
+    - ent
+    singular: entitlement
   scope: Namespaced
   versions:
   - name: v1
@@ -308,15 +308,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ringfencerules-v16.beta.appgate.com
+  name: ringfencerules.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: RingfenceRule-v16
-    plural: ringfencerules-v16
+    kind: RingfenceRule
+    plural: ringfencerules
     shortNames:
-    - rin-v16
-    singular: ringfencerule-v16
+    - rin
+    singular: ringfencerule
   scope: Namespaced
   versions:
   - name: v1
@@ -371,15 +371,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliances-v16.beta.appgate.com
+  name: appliances.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: Appliance-v16
-    plural: appliances-v16
+    kind: Appliance
+    plural: appliances
     shortNames:
-    - app-v16
-    singular: appliance-v16
+    - app
+    singular: appliance
   scope: Namespaced
   versions:
   - name: v1
@@ -1058,15 +1058,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: sites-v16.beta.appgate.com
+  name: sites.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: Site-v16
-    plural: sites-v16
+    kind: Site
+    plural: sites
     shortNames:
-    - sit-v16
-    singular: site-v16
+    - sit
+    singular: site
   scope: Namespaced
   versions:
   - name: v1
@@ -1351,15 +1351,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ippools-v16.beta.appgate.com
+  name: ippools.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: IpPool-v16
-    plural: ippools-v16
+    kind: IpPool
+    plural: ippools
     shortNames:
-    - ipp-v16
-    singular: ippool-v16
+    - ipp
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1
@@ -1407,15 +1407,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: identityproviders-v16.beta.appgate.com
+  name: identityproviders.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: IdentityProvider-v16
-    plural: identityproviders-v16
+    kind: IdentityProvider
+    plural: identityproviders
     shortNames:
-    - ide-v16
-    singular: identityprovider-v16
+    - ide
+    singular: identityprovider
   scope: Namespaced
   versions:
   - name: v1
@@ -1633,15 +1633,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: localusers-v16.beta.appgate.com
+  name: localusers.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: LocalUser-v16
-    plural: localusers-v16
+    kind: LocalUser
+    plural: localusers
     shortNames:
-    - loc-v16
-    singular: localuser-v16
+    - loc
+    singular: localuser
   scope: Namespaced
   versions:
   - name: v1
@@ -1689,15 +1689,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: administrativeroles-v16.beta.appgate.com
+  name: administrativeroles.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: AdministrativeRole-v16
-    plural: administrativeroles-v16
+    kind: AdministrativeRole
+    plural: administrativeroles
     shortNames:
-    - adm-v16
-    singular: administrativerole-v16
+    - adm
+    singular: administrativerole
   scope: Namespaced
   versions:
   - name: v1
@@ -1754,15 +1754,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: mfaproviders-v16.beta.appgate.com
+  name: mfaproviders.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: MfaProvider-v16
-    plural: mfaproviders-v16
+    kind: MfaProvider
+    plural: mfaproviders
     shortNames:
-    - mfa-v16
-    singular: mfaprovider-v16
+    - mfa
+    singular: mfaprovider
   scope: Namespaced
   versions:
   - name: v1
@@ -1819,15 +1819,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: adminmfasettingss-v16.beta.appgate.com
+  name: adminmfasettingss.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: AdminMfaSettings-v16
-    plural: adminmfasettingss-v16
+    kind: AdminMfaSettings
+    plural: adminmfasettingss
     shortNames:
-    - adi-v16
-    singular: adminmfasettings-v16
+    - adi
+    singular: adminmfasettings
   scope: Namespaced
   versions:
   - name: v1
@@ -1850,15 +1850,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: trustedcertificates-v16.beta.appgate.com
+  name: trustedcertificates.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: TrustedCertificate-v16
-    plural: trustedcertificates-v16
+    kind: TrustedCertificate
+    plural: trustedcertificates
     shortNames:
-    - tru-v16
-    singular: trustedcertificate-v16
+    - tru
+    singular: trustedcertificate
   scope: Namespaced
   versions:
   - name: v1
@@ -1889,15 +1889,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: criteriascriptss-v16.beta.appgate.com
+  name: criteriascriptss.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: CriteriaScripts-v16
-    plural: criteriascriptss-v16
+    kind: CriteriaScripts
+    plural: criteriascriptss
     shortNames:
-    - cri-v16
-    singular: criteriascripts-v16
+    - cri
+    singular: criteriascripts
   scope: Namespaced
   versions:
   - name: v1
@@ -1928,15 +1928,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: devicescripts-v16.beta.appgate.com
+  name: devicescripts.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: DeviceScript-v16
-    plural: devicescripts-v16
+    kind: DeviceScript
+    plural: devicescripts
     shortNames:
-    - dev-v16
-    singular: devicescript-v16
+    - dev
+    singular: devicescript
   scope: Namespaced
   versions:
   - name: v1
@@ -1970,15 +1970,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlementscripts-v16.beta.appgate.com
+  name: entitlementscripts.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: EntitlementScript-v16
-    plural: entitlementscripts-v16
+    kind: EntitlementScript
+    plural: entitlementscripts
     shortNames:
-    - enr-v16
-    singular: entitlementscript-v16
+    - enr
+    singular: entitlementscript
   scope: Namespaced
   versions:
   - name: v1
@@ -2012,15 +2012,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliancecustomizations-v16.beta.appgate.com
+  name: appliancecustomizations.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: ApplianceCustomization-v16
-    plural: appliancecustomizations-v16
+    kind: ApplianceCustomization
+    plural: appliancecustomizations
     shortNames:
-    - apt-v16
-    singular: appliancecustomization-v16
+    - apt
+    singular: appliancecustomization
   scope: Namespaced
   versions:
   - name: v1
@@ -2051,15 +2051,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: globalsettingss-v16.beta.appgate.com
+  name: globalsettingss.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: GlobalSettings-v16
-    plural: globalsettingss-v16
+    kind: GlobalSettings
+    plural: globalsettingss
     shortNames:
-    - glo-v16
-    singular: globalsettings-v16
+    - glo
+    singular: globalsettings
   scope: Namespaced
   versions:
   - name: v1
@@ -2112,15 +2112,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clientconnections-v16.beta.appgate.com
+  name: clientconnections.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: ClientConnection-v16
-    plural: clientconnections-v16
+    kind: ClientConnection
+    plural: clientconnections
     shortNames:
-    - cli-v16
-    singular: clientconnection-v16
+    - cli
+    singular: clientconnection
   scope: Namespaced
   versions:
   - name: v1

--- a/k8s/crd/templates/v17.yaml
+++ b/k8s/crd/templates/v17.yaml
@@ -2,15 +2,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: policies-v17.beta.appgate.com
+  name: policies.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: Policy-v17
-    plural: policies-v17
+    kind: Policy
+    plural: policies
     shortNames:
-    - pol-v17
-    singular: policy-v17
+    - pol
+    singular: policy
   scope: Namespaced
   versions:
   - name: v1
@@ -140,15 +140,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: conditions-v17.beta.appgate.com
+  name: conditions.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: Condition-v17
-    plural: conditions-v17
+    kind: Condition
+    plural: conditions
     shortNames:
-    - con-v17
-    singular: condition-v17
+    - con
+    singular: condition
   scope: Namespaced
   versions:
   - name: v1
@@ -203,15 +203,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlements-v17.beta.appgate.com
+  name: entitlements.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: Entitlement-v17
-    plural: entitlements-v17
+    kind: Entitlement
+    plural: entitlements
     shortNames:
-    - ent-v17
-    singular: entitlement-v17
+    - ent
+    singular: entitlement
   scope: Namespaced
   versions:
   - name: v1
@@ -310,15 +310,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ringfencerules-v17.beta.appgate.com
+  name: ringfencerules.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: RingfenceRule-v17
-    plural: ringfencerules-v17
+    kind: RingfenceRule
+    plural: ringfencerules
     shortNames:
-    - rin-v17
-    singular: ringfencerule-v17
+    - rin
+    singular: ringfencerule
   scope: Namespaced
   versions:
   - name: v1
@@ -373,15 +373,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliances-v17.beta.appgate.com
+  name: appliances.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: Appliance-v17
-    plural: appliances-v17
+    kind: Appliance
+    plural: appliances
     shortNames:
-    - app-v17
-    singular: appliance-v17
+    - app
+    singular: appliance
   scope: Namespaced
   versions:
   - name: v1
@@ -1041,15 +1041,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: sites-v17.beta.appgate.com
+  name: sites.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: Site-v17
-    plural: sites-v17
+    kind: Site
+    plural: sites
     shortNames:
-    - sit-v17
-    singular: site-v17
+    - sit
+    singular: site
   scope: Namespaced
   versions:
   - name: v1
@@ -1339,15 +1339,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ippools-v17.beta.appgate.com
+  name: ippools.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: IpPool-v17
-    plural: ippools-v17
+    kind: IpPool
+    plural: ippools
     shortNames:
-    - ipp-v17
-    singular: ippool-v17
+    - ipp
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1
@@ -1395,15 +1395,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: identityproviders-v17.beta.appgate.com
+  name: identityproviders.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: IdentityProvider-v17
-    plural: identityproviders-v17
+    kind: IdentityProvider
+    plural: identityproviders
     shortNames:
-    - ide-v17
-    singular: identityprovider-v17
+    - ide
+    singular: identityprovider
   scope: Namespaced
   versions:
   - name: v1
@@ -1624,15 +1624,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: localusers-v17.beta.appgate.com
+  name: localusers.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: LocalUser-v17
-    plural: localusers-v17
+    kind: LocalUser
+    plural: localusers
     shortNames:
-    - loc-v17
-    singular: localuser-v17
+    - loc
+    singular: localuser
   scope: Namespaced
   versions:
   - name: v1
@@ -1682,15 +1682,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: serviceusers-v17.beta.appgate.com
+  name: serviceusers.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: ServiceUser-v17
-    plural: serviceusers-v17
+    kind: ServiceUser
+    plural: serviceusers
     shortNames:
-    - ser-v17
-    singular: serviceuser-v17
+    - ser
+    singular: serviceuser
   scope: Namespaced
   versions:
   - name: v1
@@ -1730,15 +1730,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: administrativeroles-v17.beta.appgate.com
+  name: administrativeroles.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: AdministrativeRole-v17
-    plural: administrativeroles-v17
+    kind: AdministrativeRole
+    plural: administrativeroles
     shortNames:
-    - adm-v17
-    singular: administrativerole-v17
+    - adm
+    singular: administrativerole
   scope: Namespaced
   versions:
   - name: v1
@@ -1799,15 +1799,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: mfaproviders-v17.beta.appgate.com
+  name: mfaproviders.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: MfaProvider-v17
-    plural: mfaproviders-v17
+    kind: MfaProvider
+    plural: mfaproviders
     shortNames:
-    - mfa-v17
-    singular: mfaprovider-v17
+    - mfa
+    singular: mfaprovider
   scope: Namespaced
   versions:
   - name: v1
@@ -1864,15 +1864,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: adminmfasettingss-v17.beta.appgate.com
+  name: adminmfasettingss.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: AdminMfaSettings-v17
-    plural: adminmfasettingss-v17
+    kind: AdminMfaSettings
+    plural: adminmfasettingss
     shortNames:
-    - adi-v17
-    singular: adminmfasettings-v17
+    - adi
+    singular: adminmfasettings
   scope: Namespaced
   versions:
   - name: v1
@@ -1895,15 +1895,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: trustedcertificates-v17.beta.appgate.com
+  name: trustedcertificates.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: TrustedCertificate-v17
-    plural: trustedcertificates-v17
+    kind: TrustedCertificate
+    plural: trustedcertificates
     shortNames:
-    - tru-v17
-    singular: trustedcertificate-v17
+    - tru
+    singular: trustedcertificate
   scope: Namespaced
   versions:
   - name: v1
@@ -1934,15 +1934,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: criteriascriptss-v17.beta.appgate.com
+  name: criteriascriptss.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: CriteriaScripts-v17
-    plural: criteriascriptss-v17
+    kind: CriteriaScripts
+    plural: criteriascriptss
     shortNames:
-    - cri-v17
-    singular: criteriascripts-v17
+    - cri
+    singular: criteriascripts
   scope: Namespaced
   versions:
   - name: v1
@@ -1973,15 +1973,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: devicescripts-v17.beta.appgate.com
+  name: devicescripts.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: DeviceScript-v17
-    plural: devicescripts-v17
+    kind: DeviceScript
+    plural: devicescripts
     shortNames:
-    - dev-v17
-    singular: devicescript-v17
+    - dev
+    singular: devicescript
   scope: Namespaced
   versions:
   - name: v1
@@ -2015,15 +2015,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlementscripts-v17.beta.appgate.com
+  name: entitlementscripts.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: EntitlementScript-v17
-    plural: entitlementscripts-v17
+    kind: EntitlementScript
+    plural: entitlementscripts
     shortNames:
-    - enr-v17
-    singular: entitlementscript-v17
+    - enr
+    singular: entitlementscript
   scope: Namespaced
   versions:
   - name: v1
@@ -2057,15 +2057,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliancecustomizations-v17.beta.appgate.com
+  name: appliancecustomizations.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: ApplianceCustomization-v17
-    plural: appliancecustomizations-v17
+    kind: ApplianceCustomization
+    plural: appliancecustomizations
     shortNames:
-    - apt-v17
-    singular: appliancecustomization-v17
+    - apt
+    singular: appliancecustomization
   scope: Namespaced
   versions:
   - name: v1
@@ -2096,15 +2096,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: globalsettingss-v17.beta.appgate.com
+  name: globalsettingss.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: GlobalSettings-v17
-    plural: globalsettingss-v17
+    kind: GlobalSettings
+    plural: globalsettingss
     shortNames:
-    - glo-v17
-    singular: globalsettings-v17
+    - glo
+    singular: globalsettings
   scope: Namespaced
   versions:
   - name: v1
@@ -2166,15 +2166,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clientconnections-v17.beta.appgate.com
+  name: clientconnections.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: ClientConnection-v17
-    plural: clientconnections-v17
+    kind: ClientConnection
+    plural: clientconnections
     shortNames:
-    - cli-v17
-    singular: clientconnection-v17
+    - cli
+    singular: clientconnection
   scope: Namespaced
   versions:
   - name: v1

--- a/k8s/crd/templates/v18.yaml
+++ b/k8s/crd/templates/v18.yaml
@@ -2,15 +2,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: policies-v18.beta.appgate.com
+  name: policies.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: Policy-v18
-    plural: policies-v18
+    kind: Policy
+    plural: policies
     shortNames:
-    - pol-v18
-    singular: policy-v18
+    - pol
+    singular: policy
   scope: Namespaced
   versions:
   - name: v1
@@ -152,15 +152,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: conditions-v18.beta.appgate.com
+  name: conditions.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: Condition-v18
-    plural: conditions-v18
+    kind: Condition
+    plural: conditions
     shortNames:
-    - con-v18
-    singular: condition-v18
+    - con
+    singular: condition
   scope: Namespaced
   versions:
   - name: v1
@@ -215,15 +215,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlements-v18.beta.appgate.com
+  name: entitlements.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: Entitlement-v18
-    plural: entitlements-v18
+    kind: Entitlement
+    plural: entitlements
     shortNames:
-    - ent-v18
-    singular: entitlement-v18
+    - ent
+    singular: entitlement
   scope: Namespaced
   versions:
   - name: v1
@@ -326,15 +326,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ringfencerules-v18.beta.appgate.com
+  name: ringfencerules.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: RingfenceRule-v18
-    plural: ringfencerules-v18
+    kind: RingfenceRule
+    plural: ringfencerules
     shortNames:
-    - rin-v18
-    singular: ringfencerule-v18
+    - rin
+    singular: ringfencerule
   scope: Namespaced
   versions:
   - name: v1
@@ -389,15 +389,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliances-v18.beta.appgate.com
+  name: appliances.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: Appliance-v18
-    plural: appliances-v18
+    kind: Appliance
+    plural: appliances
     shortNames:
-    - app-v18
-    singular: appliance-v18
+    - app
+    singular: appliance
   scope: Namespaced
   versions:
   - name: v1
@@ -1081,15 +1081,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: sites-v18.beta.appgate.com
+  name: sites.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: Site-v18
-    plural: sites-v18
+    kind: Site
+    plural: sites
     shortNames:
-    - sit-v18
-    singular: site-v18
+    - sit
+    singular: site
   scope: Namespaced
   versions:
   - name: v1
@@ -1406,15 +1406,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ippools-v18.beta.appgate.com
+  name: ippools.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: IpPool-v18
-    plural: ippools-v18
+    kind: IpPool
+    plural: ippools
     shortNames:
-    - ipp-v18
-    singular: ippool-v18
+    - ipp
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1
@@ -1476,15 +1476,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: identityproviders-v18.beta.appgate.com
+  name: identityproviders.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: IdentityProvider-v18
-    plural: identityproviders-v18
+    kind: IdentityProvider
+    plural: identityproviders
     shortNames:
-    - ide-v18
-    singular: identityprovider-v18
+    - ide
+    singular: identityprovider
   scope: Namespaced
   versions:
   - name: v1
@@ -1708,15 +1708,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: localusers-v18.beta.appgate.com
+  name: localusers.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: LocalUser-v18
-    plural: localusers-v18
+    kind: LocalUser
+    plural: localusers
     shortNames:
-    - loc-v18
-    singular: localuser-v18
+    - loc
+    singular: localuser
   scope: Namespaced
   versions:
   - name: v1
@@ -1766,15 +1766,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: serviceusers-v18.beta.appgate.com
+  name: serviceusers.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: ServiceUser-v18
-    plural: serviceusers-v18
+    kind: ServiceUser
+    plural: serviceusers
     shortNames:
-    - ser-v18
-    singular: serviceuser-v18
+    - ser
+    singular: serviceuser
   scope: Namespaced
   versions:
   - name: v1
@@ -1814,15 +1814,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: administrativeroles-v18.beta.appgate.com
+  name: administrativeroles.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: AdministrativeRole-v18
-    plural: administrativeroles-v18
+    kind: AdministrativeRole
+    plural: administrativeroles
     shortNames:
-    - adm-v18
-    singular: administrativerole-v18
+    - adm
+    singular: administrativerole
   scope: Namespaced
   versions:
   - name: v1
@@ -1883,15 +1883,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: mfaproviders-v18.beta.appgate.com
+  name: mfaproviders.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: MfaProvider-v18
-    plural: mfaproviders-v18
+    kind: MfaProvider
+    plural: mfaproviders
     shortNames:
-    - mfa-v18
-    singular: mfaprovider-v18
+    - mfa
+    singular: mfaprovider
   scope: Namespaced
   versions:
   - name: v1
@@ -1948,15 +1948,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: adminmfasettingss-v18.beta.appgate.com
+  name: adminmfasettingss.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: AdminMfaSettings-v18
-    plural: adminmfasettingss-v18
+    kind: AdminMfaSettings
+    plural: adminmfasettingss
     shortNames:
-    - adi-v18
-    singular: adminmfasettings-v18
+    - adi
+    singular: adminmfasettings
   scope: Namespaced
   versions:
   - name: v1
@@ -1979,15 +1979,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: trustedcertificates-v18.beta.appgate.com
+  name: trustedcertificates.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: TrustedCertificate-v18
-    plural: trustedcertificates-v18
+    kind: TrustedCertificate
+    plural: trustedcertificates
     shortNames:
-    - tru-v18
-    singular: trustedcertificate-v18
+    - tru
+    singular: trustedcertificate
   scope: Namespaced
   versions:
   - name: v1
@@ -2018,15 +2018,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: criteriascriptss-v18.beta.appgate.com
+  name: criteriascriptss.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: CriteriaScripts-v18
-    plural: criteriascriptss-v18
+    kind: CriteriaScripts
+    plural: criteriascriptss
     shortNames:
-    - cri-v18
-    singular: criteriascripts-v18
+    - cri
+    singular: criteriascripts
   scope: Namespaced
   versions:
   - name: v1
@@ -2057,15 +2057,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: devicescripts-v18.beta.appgate.com
+  name: devicescripts.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: DeviceScript-v18
-    plural: devicescripts-v18
+    kind: DeviceScript
+    plural: devicescripts
     shortNames:
-    - dev-v18
-    singular: devicescript-v18
+    - dev
+    singular: devicescript
   scope: Namespaced
   versions:
   - name: v1
@@ -2099,15 +2099,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlementscripts-v18.beta.appgate.com
+  name: entitlementscripts.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: EntitlementScript-v18
-    plural: entitlementscripts-v18
+    kind: EntitlementScript
+    plural: entitlementscripts
     shortNames:
-    - enr-v18
-    singular: entitlementscript-v18
+    - enr
+    singular: entitlementscript
   scope: Namespaced
   versions:
   - name: v1
@@ -2141,15 +2141,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliancecustomizations-v18.beta.appgate.com
+  name: appliancecustomizations.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: ApplianceCustomization-v18
-    plural: appliancecustomizations-v18
+    kind: ApplianceCustomization
+    plural: appliancecustomizations
     shortNames:
-    - apt-v18
-    singular: appliancecustomization-v18
+    - apt
+    singular: appliancecustomization
   scope: Namespaced
   versions:
   - name: v1
@@ -2180,15 +2180,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: globalsettingss-v18.beta.appgate.com
+  name: globalsettingss.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: GlobalSettings-v18
-    plural: globalsettingss-v18
+    kind: GlobalSettings
+    plural: globalsettingss
     shortNames:
-    - glo-v18
-    singular: globalsettings-v18
+    - glo
+    singular: globalsettings
   scope: Namespaced
   versions:
   - name: v1
@@ -2250,15 +2250,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clientconnections-v18.beta.appgate.com
+  name: clientconnections.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: ClientConnection-v18
-    plural: clientconnections-v18
+    kind: ClientConnection
+    plural: clientconnections
     shortNames:
-    - cli-v18
-    singular: clientconnection-v18
+    - cli
+    singular: clientconnection
   scope: Namespaced
   versions:
   - name: v1

--- a/k8s/operator/templates/rbac.yaml
+++ b/k8s/operator/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
   {{- include "sdp-operator.labels" . | nindent 4 }}
 rules:
-  - apiGroups: ["v14.sdp.appgate.com", "v15.sdp.appgate.com", "v16.sdp.appgate.com", "v17.sdp.appgate.com", "v18.sdp.appgate.com"]
+  - apiGroups: [ "{{ .Values.sdp.operator.version }}.sdp.appgate.com" ]
     resources:
       - policies
       - entitlements

--- a/k8s/operator/templates/rbac.yaml
+++ b/k8s/operator/templates/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "sdp-operator.name" . }}
+  name: {{ include "sdp-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "sdp-operator.labels" . | nindent 4 }}
@@ -37,7 +37,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "sdp-operator.name" . }}
+  name: {{ include "sdp-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "sdp-operator.labels" . | nindent 4 }}
@@ -47,6 +47,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ include "sdp-operator.name" . }}
+  name: {{ include "sdp-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/k8s/operator/templates/rbac.yaml
+++ b/k8s/operator/templates/rbac.yaml
@@ -7,28 +7,28 @@ metadata:
   labels:
   {{- include "sdp-operator.labels" . | nindent 4 }}
 rules:
-  - apiGroups: ["beta.appgate.com"]
+  - apiGroups: ["v14.sdp.appgate.com", "v15.sdp.appgate.com", "v16.sdp.appgate.com", "v17.sdp.appgate.com", "v18.sdp.appgate.com"]
     resources:
-      - policies-{{ .Values.sdp.operator.version }}
-      - entitlements-{{ .Values.sdp.operator.version }}
-      - conditions-{{ .Values.sdp.operator.version }}
-      - ringfencerules-{{ .Values.sdp.operator.version }}
-      - appliances-{{ .Values.sdp.operator.version }}
-      - sites-{{ .Values.sdp.operator.version }}
-      - ippools-{{ .Values.sdp.operator.version }}
-      - identityproviders-{{ .Values.sdp.operator.version }}
-      - localusers-{{ .Values.sdp.operator.version }}
-      - administrativeroles-{{ .Values.sdp.operator.version }}
-      - mfaproviders-{{ .Values.sdp.operator.version }}
-      - adminmfasettingss-{{ .Values.sdp.operator.version }}
-      - trustedcertificates-{{ .Values.sdp.operator.version }}
-      - criteriascriptss-{{ .Values.sdp.operator.version }}
-      - devicescripts-{{ .Values.sdp.operator.version }}
-      - entitlementscripts-{{ .Values.sdp.operator.version }}
-      - appliancecustomizations-{{ .Values.sdp.operator.version }}
-      - globalsettingss-{{ .Values.sdp.operator.version }}
-      - clientconnections-{{ .Values.sdp.operator.version }}
-      - serviceusers-{{ .Values.sdp.operator.version }}
+      - policies
+      - entitlements
+      - conditions
+      - ringfencerules
+      - appliances
+      - sites
+      - ippools
+      - identityproviders
+      - localusers
+      - administrativeroles
+      - mfaproviders
+      - adminmfasettingss
+      - trustedcertificates
+      - criteriascriptss
+      - devicescripts
+      - entitlementscripts
+      - appliancecustomizations
+      - globalsettingss
+      - clientconnections
+      - serviceusers
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
     resources: ["configmaps", "secrets"]

--- a/tests/resources/crd/v14/appliance.yaml
+++ b/tests/resources/crd/v14/appliance.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliances-v14.beta.appgate.com
+  name: appliances.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: Appliance-v14
-    plural: appliances-v14
+    kind: Appliance
+    plural: appliances
     shortNames:
-    - app-v14
-    singular: appliance-v14
+    - app
+    singular: appliance
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v14/condition.yaml
+++ b/tests/resources/crd/v14/condition.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: conditions-v14.beta.appgate.com
+  name: conditions.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: Condition-v14
-    plural: conditions-v14
+    kind: Condition
+    plural: conditions
     shortNames:
-    - con-v14
-    singular: condition-v14
+    - con
+    singular: condition
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v14/entitlement.yaml
+++ b/tests/resources/crd/v14/entitlement.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlements-v14.beta.appgate.com
+  name: entitlements.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: Entitlement-v14
-    plural: entitlements-v14
+    kind: Entitlement
+    plural: entitlements
     shortNames:
-    - ent-v14
-    singular: entitlement-v14
+    - ent
+    singular: entitlement
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v14/identityprovider.yaml
+++ b/tests/resources/crd/v14/identityprovider.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: identityproviders-v14.beta.appgate.com
+  name: identityproviders.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: IdentityProvider-v14
-    plural: identityproviders-v14
+    kind: IdentityProvider
+    plural: identityproviders
     shortNames:
-    - ide-v14
-    singular: identityprovider-v14
+    - ide
+    singular: identityprovider
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v14/ippool.yaml
+++ b/tests/resources/crd/v14/ippool.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ippools-v14.beta.appgate.com
+  name: ippools.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: IpPool-v14
-    plural: ippools-v14
+    kind: IpPool
+    plural: ippools
     shortNames:
-    - ipp-v14
-    singular: ippool-v14
+    - ipp
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v14/policy.yaml
+++ b/tests/resources/crd/v14/policy.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: policies-v14.beta.appgate.com
+  name: policies.v14.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v14.sdp.appgate.com
   names:
-    kind: Policy-v14
-    plural: policies-v14
+    kind: Policy
+    plural: policies
     shortNames:
-    - pol-v14
-    singular: policy-v14
+    - pol
+    singular: policy
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v15/appliance.yaml
+++ b/tests/resources/crd/v15/appliance.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliances-v15.beta.appgate.com
+  name: appliances.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: Appliance-v15
-    plural: appliances-v15
+    kind: Appliance
+    plural: appliances
     shortNames:
-    - app-v15
-    singular: appliance-v15
+    - app
+    singular: appliance
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v15/condition.yaml
+++ b/tests/resources/crd/v15/condition.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: conditions-v15.beta.appgate.com
+  name: conditions.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: Condition-v15
-    plural: conditions-v15
+    kind: Condition
+    plural: conditions
     shortNames:
-    - con-v15
-    singular: condition-v15
+    - con
+    singular: condition
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v15/entitlement.yaml
+++ b/tests/resources/crd/v15/entitlement.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlements-v15.beta.appgate.com
+  name: entitlements.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: Entitlement-v15
-    plural: entitlements-v15
+    kind: Entitlement
+    plural: entitlements
     shortNames:
-    - ent-v15
-    singular: entitlement-v15
+    - ent
+    singular: entitlement
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v15/identityprovider.yaml
+++ b/tests/resources/crd/v15/identityprovider.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: identityproviders-v15.beta.appgate.com
+  name: identityproviders.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: IdentityProvider-v15
-    plural: identityproviders-v15
+    kind: IdentityProvider
+    plural: identityproviders
     shortNames:
-    - ide-v15
-    singular: identityprovider-v15
+    - ide
+    singular: identityprovider
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v15/ippool.yaml
+++ b/tests/resources/crd/v15/ippool.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ippools-v15.beta.appgate.com
+  name: ippools.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: IpPool-v15
-    plural: ippools-v15
+    kind: IpPool
+    plural: ippools
     shortNames:
-    - ipp-v15
-    singular: ippool-v15
+    - ipp
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v15/policy.yaml
+++ b/tests/resources/crd/v15/policy.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: policies-v15.beta.appgate.com
+  name: policies.v15.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v15.sdp.appgate.com
   names:
-    kind: Policy-v15
-    plural: policies-v15
+    kind: Policy
+    plural: policies
     shortNames:
-    - pol-v15
-    singular: policy-v15
+    - pol
+    singular: policy
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v16/appliance.yaml
+++ b/tests/resources/crd/v16/appliance.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliances-v16.beta.appgate.com
+  name: appliances.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: Appliance-v16
-    plural: appliances-v16
+    kind: Appliance
+    plural: appliances
     shortNames:
-    - app-v16
-    singular: appliance-v16
+    - app
+    singular: appliance
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v16/condition.yaml
+++ b/tests/resources/crd/v16/condition.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: conditions-v16.beta.appgate.com
+  name: conditions.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: Condition-v16
-    plural: conditions-v16
+    kind: Condition
+    plural: conditions
     shortNames:
-    - con-v16
-    singular: condition-v16
+    - con
+    singular: condition
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v16/entitlement.yaml
+++ b/tests/resources/crd/v16/entitlement.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlements-v16.beta.appgate.com
+  name: entitlements.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: Entitlement-v16
-    plural: entitlements-v16
+    kind: Entitlement
+    plural: entitlements
     shortNames:
-    - ent-v16
-    singular: entitlement-v16
+    - ent
+    singular: entitlement
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v16/identityprovider.yaml
+++ b/tests/resources/crd/v16/identityprovider.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: identityproviders-v16.beta.appgate.com
+  name: identityproviders.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: IdentityProvider-v16
-    plural: identityproviders-v16
+    kind: IdentityProvider
+    plural: identityproviders
     shortNames:
-    - ide-v16
-    singular: identityprovider-v16
+    - ide
+    singular: identityprovider
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v16/ippool.yaml
+++ b/tests/resources/crd/v16/ippool.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ippools-v16.beta.appgate.com
+  name: ippools.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: IpPool-v16
-    plural: ippools-v16
+    kind: IpPool
+    plural: ippools
     shortNames:
-    - ipp-v16
-    singular: ippool-v16
+    - ipp
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v16/policy.yaml
+++ b/tests/resources/crd/v16/policy.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: policies-v16.beta.appgate.com
+  name: policies.v16.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v16.sdp.appgate.com
   names:
-    kind: Policy-v16
-    plural: policies-v16
+    kind: Policy
+    plural: policies
     shortNames:
-    - pol-v16
-    singular: policy-v16
+    - pol
+    singular: policy
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v17/appliance.yaml
+++ b/tests/resources/crd/v17/appliance.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliances-v17.beta.appgate.com
+  name: appliances.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: Appliance-v17
-    plural: appliances-v17
+    kind: Appliance
+    plural: appliances
     shortNames:
-    - app-v17
-    singular: appliance-v17
+    - app
+    singular: appliance
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v17/condition.yaml
+++ b/tests/resources/crd/v17/condition.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: conditions-v17.beta.appgate.com
+  name: conditions.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: Condition-v17
-    plural: conditions-v17
+    kind: Condition
+    plural: conditions
     shortNames:
-    - con-v17
-    singular: condition-v17
+    - con
+    singular: condition
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v17/entitlement.yaml
+++ b/tests/resources/crd/v17/entitlement.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlements-v17.beta.appgate.com
+  name: entitlements.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: Entitlement-v17
-    plural: entitlements-v17
+    kind: Entitlement
+    plural: entitlements
     shortNames:
-    - ent-v17
-    singular: entitlement-v17
+    - ent
+    singular: entitlement
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v17/identityprovider.yaml
+++ b/tests/resources/crd/v17/identityprovider.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: identityproviders-v17.beta.appgate.com
+  name: identityproviders.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: IdentityProvider-v17
-    plural: identityproviders-v17
+    kind: IdentityProvider
+    plural: identityproviders
     shortNames:
-    - ide-v17
-    singular: identityprovider-v17
+    - ide
+    singular: identityprovider
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v17/ippool.yaml
+++ b/tests/resources/crd/v17/ippool.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ippools-v17.beta.appgate.com
+  name: ippools.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: IpPool-v17
-    plural: ippools-v17
+    kind: IpPool
+    plural: ippools
     shortNames:
-    - ipp-v17
-    singular: ippool-v17
+    - ipp
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v17/policy.yaml
+++ b/tests/resources/crd/v17/policy.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: policies-v17.beta.appgate.com
+  name: policies.v17.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v17.sdp.appgate.com
   names:
-    kind: Policy-v17
-    plural: policies-v17
+    kind: Policy
+    plural: policies
     shortNames:
-    - pol-v17
-    singular: policy-v17
+    - pol
+    singular: policy
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v18/appliance.yaml
+++ b/tests/resources/crd/v18/appliance.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: appliances-v18.beta.appgate.com
+  name: appliances.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: Appliance-v18
-    plural: appliances-v18
+    kind: Appliance
+    plural: appliances
     shortNames:
-    - app-v18
-    singular: appliance-v18
+    - app
+    singular: appliance
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v18/condition.yaml
+++ b/tests/resources/crd/v18/condition.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: conditions-v18.beta.appgate.com
+  name: conditions.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: Condition-v18
-    plural: conditions-v18
+    kind: Condition
+    plural: conditions
     shortNames:
-    - con-v18
-    singular: condition-v18
+    - con
+    singular: condition
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v18/entitlement.yaml
+++ b/tests/resources/crd/v18/entitlement.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: entitlements-v18.beta.appgate.com
+  name: entitlements.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: Entitlement-v18
-    plural: entitlements-v18
+    kind: Entitlement
+    plural: entitlements
     shortNames:
-    - ent-v18
-    singular: entitlement-v18
+    - ent
+    singular: entitlement
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v18/identityprovider.yaml
+++ b/tests/resources/crd/v18/identityprovider.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: identityproviders-v18.beta.appgate.com
+  name: identityproviders.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: IdentityProvider-v18
-    plural: identityproviders-v18
+    kind: IdentityProvider
+    plural: identityproviders
     shortNames:
-    - ide-v18
-    singular: identityprovider-v18
+    - ide
+    singular: identityprovider
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v18/ippool.yaml
+++ b/tests/resources/crd/v18/ippool.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ippools-v18.beta.appgate.com
+  name: ippools.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: IpPool-v18
-    plural: ippools-v18
+    kind: IpPool
+    plural: ippools
     shortNames:
-    - ipp-v18
-    singular: ippool-v18
+    - ipp
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1

--- a/tests/resources/crd/v18/policy.yaml
+++ b/tests/resources/crd/v18/policy.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: policies-v18.beta.appgate.com
+  name: policies.v18.sdp.appgate.com
 spec:
-  group: beta.appgate.com
+  group: v18.sdp.appgate.com
   names:
-    kind: Policy-v18
-    plural: policies-v18
+    kind: Policy
+    plural: policies
     shortNames:
-    - pol-v18
-    singular: policy-v18
+    - pol
+    singular: policy
   scope: Namespaced
   versions:
   - name: v1


### PR DESCRIPTION
Change the domain formatting to `<entity>.<api version>.sdp.appgate.com`

For example, `policies.v18.sdp.appgate.com`

Bonus: Use `{{ sdp-operator.fullname }}` for Role and RoleBinding. On purple, we have two deployments of the operator (dev and prod). They have overlapping role and rolebinding because the chart currently uses `{{ sdp-operator.name }}` as its names. 