### PR TITLE
Don't reuse the name in rbac in case the same NS is used for deployment

### DIFF
--- a/k8s/operator/templates/_helpers.tpl
+++ b/k8s/operator/templates/_helpers.tpl
@@ -81,3 +81,17 @@ Operator Metadata Config
 {{- define "sdp-operator.config-mt" -}}
 {{- printf "sdp-operator-config-mt-%s" .Release.Name }}
 {{- end }}
+
+{{/*
+Operator Role
+*/}}
+{{- define "sdp-operator.role" -}}
+{{- printf "role-%s" .Release.Name }}
+{{- end }}
+
+{{/*
+Operator RoleBinding
+*/}}
+{{- define "sdp-operator.rolebinding" -}}
+{{- printf "rolebinding-%s" .Release.Name }}
+{{- end }}

--- a/k8s/operator/templates/_helpers.tpl
+++ b/k8s/operator/templates/_helpers.tpl
@@ -81,17 +81,3 @@ Operator Metadata Config
 {{- define "sdp-operator.config-mt" -}}
 {{- printf "sdp-operator-config-mt-%s" .Release.Name }}
 {{- end }}
-
-{{/*
-Operator Role
-*/}}
-{{- define "sdp-operator.role" -}}
-{{- printf "role-%s" .Release.Name }}
-{{- end }}
-
-{{/*
-Operator RoleBinding
-*/}}
-{{- define "sdp-operator.rolebinding" -}}
-{{- printf "rolebinding-%s" .Release.Name }}
-{{- end }}

--- a/k8s/operator/templates/rbac.yaml
+++ b/k8s/operator/templates/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "sdp-operator.name" . }}
+  name: {{ include "sdp-operator.role" . }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "sdp-operator.labels" . | nindent 4 }}
@@ -37,7 +37,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "sdp-operator.name" . }}
+  name: {{ include "sdp-operator.rolebinding" . }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "sdp-operator.labels" . | nindent 4 }}
@@ -47,6 +47,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ include "sdp-operator.name" . }}
+  name: {{ include "sdp-operator.role" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/k8s/operator/templates/rbac.yaml
+++ b/k8s/operator/templates/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "sdp-operator.role" . }}
+  name: {{ include "sdp-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "sdp-operator.labels" . | nindent 4 }}
@@ -37,7 +37,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "sdp-operator.rolebinding" . }}
+  name: {{ include "sdp-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "sdp-operator.labels" . | nindent 4 }}
@@ -47,6 +47,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ include "sdp-operator.role" . }}
+  name: {{ include "sdp-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}


### PR DESCRIPTION
It causes conflicts when deploying the chart in the same ns twice