### PR TITLE
Only load secret/file when the operator mode is "appgate-operator"

### DIFF
--- a/appgate/__main__.py
+++ b/appgate/__main__.py
@@ -168,9 +168,7 @@ def appgate_operator_context(
         spec_directory=Path(spec_directory) if spec_directory else None,
         secrets_key=secrets_key,
         k8s_get_secret=k8s_get_secret,
-        operator_mode="appgate-reverse-operator"
-        if args.reverse_mode
-        else "appgate-operator",
+        operator_mode=get_operator_name(args.reverse_mode),
     )
 
     return AppgateOperatorContext(

--- a/appgate/__main__.py
+++ b/appgate/__main__.py
@@ -168,6 +168,9 @@ def appgate_operator_context(
         spec_directory=Path(spec_directory) if spec_directory else None,
         secrets_key=secrets_key,
         k8s_get_secret=k8s_get_secret,
+        operator_mode="appgate-reverse-operator"
+        if args.reverse_mode
+        else "appgate-operator",
     )
 
     return AppgateOperatorContext(

--- a/appgate/customloaders.py
+++ b/appgate/customloaders.py
@@ -50,12 +50,16 @@ class FileAttribLoader(CustomAttribLoader):
 
     def load(self, values: AttributesDict) -> AttributesDict:
         v = values.get(self.field)
-        if not v and self.load_external:
-            # Try loading the s value from the external source if value doesn't exist
-            v = self.loader(values)
-            if not v:
-                return values
-            values[self.field] = v
+        if not v:
+            if self.load_external:
+                # Try loading the s value from the external source if value doesn't exist
+                v = self.loader(values)
+                if not v:
+                    return values
+                values[self.field] = v
+            else:
+                # Return empty string, otherwise the loader will complain if we return None
+                values[self.field] = ""
         return values
 
 

--- a/appgate/files.py
+++ b/appgate/files.py
@@ -98,7 +98,24 @@ def appgate_file_load(value: OpenApiDict, entity_name: str) -> str:
     return appgate_file.load_file()
 
 
+def should_load_file(operator_mode: str) -> bool:
+    return "APPGATE_FILE_SOURCE" in os.environ and operator_mode == "appgate-operator"
+
+
 class FileAttribMaker(AttribMaker):
+    def __init__(
+        self,
+        name: str,
+        tpe: type,
+        base_tpe: type,
+        default: Optional[AttribType],
+        factory: Optional[type],
+        definition: OpenApiDict,
+        operator_mode: str,
+    ) -> None:
+        super().__init__(name, tpe, base_tpe, default, factory, definition)
+        self.operator_mode = operator_mode
+
     def values(
         self,
         attributes: Dict[str, "AttribMaker"],
@@ -114,7 +131,7 @@ class FileAttribMaker(AttribMaker):
                     v, instance_maker_config.entity_name
                 ),
                 field=self.name,
-                load_external="APPGATE_FILE_SOURCE" in os.environ,
+                load_external=should_load_file(self.operator_mode),
             )
         ]
         return values

--- a/appgate/openapi/openapi.py
+++ b/appgate/openapi/openapi.py
@@ -43,6 +43,7 @@ LIST_PROPERTIES = {"range", "data", "query", "orderBy", "descending", "filterBy"
 
 def parse_files(
     spec_entities: Dict[str, str],
+    operator_mode: str,
     spec_directory: Optional[Path] = None,
     spec_file: str = "api_specs.yml",
     k8s_get_secret: Optional[Callable[[str, str], str]] = None,
@@ -53,6 +54,7 @@ def parse_files(
         spec_api_path=spec_directory or Path(SPEC_DIR),
         secrets_key=secrets_key,
         k8s_get_secret=k8s_get_secret,
+        operator_mode=operator_mode,
     )
     parser = Parser(parser_context, spec_file)
     # First parse those paths we are interested in
@@ -275,6 +277,7 @@ def generate_api_spec(
     spec_directory: Optional[Path] = None,
     secrets_key: Optional[str] = None,
     k8s_get_secret: Optional[Callable[[str, str], str]] = None,
+    operator_mode: str = "appgate-operator",
 ) -> APISpec:
     """
     Parses openapi yaml files and generates the ApiSpec.
@@ -284,6 +287,7 @@ def generate_api_spec(
         spec_directory=spec_directory,
         secrets_key=secrets_key,
         k8s_get_secret=k8s_get_secret,
+        operator_mode=operator_mode,
     )
 
 

--- a/appgate/openapi/parser.py
+++ b/appgate/openapi/parser.py
@@ -247,6 +247,7 @@ class ParserContext:
         spec_api_path: Path,
         secrets_key: Optional[str],
         k8s_get_secret: Optional[Callable[[str, str], str]],
+        operator_mode: str,
     ) -> None:
         self.secrets_cipher = Fernet(secrets_key.encode()) if secrets_key else None
         self.entities: Dict[str, GeneratedEntity] = {}
@@ -257,6 +258,7 @@ class ParserContext:
             v: k for k, v in spec_entities.items()
         }
         self.k8s_get_secret = k8s_get_secret
+        self.operator_mode = operator_mode
 
     def get_entity_path(self, entity_name: str) -> Optional[str]:
         return self.entity_path_by_name.get(entity_name)
@@ -520,6 +522,7 @@ class Parser:
                     definition=attrib_maker_config.definition,
                     secrets_cipher=self.parser_context.secrets_cipher,
                     k8s_get_client=self.parser_context.k8s_get_secret,
+                    operator_mode=self.parser_context.operator_mode,
                 )
             elif format == "date-time":
                 return AttribMaker(

--- a/appgate/openapi/parser.py
+++ b/appgate/openapi/parser.py
@@ -541,6 +541,7 @@ class Parser:
                     default=None,
                     factory=None,
                     definition=attrib_maker_config.definition,
+                    operator_mode=self.parser_context.operator_mode,
                 )
             elif (
                 format == "checksum"

--- a/appgate/secrets.py
+++ b/appgate/secrets.py
@@ -233,10 +233,12 @@ class PasswordAttribMaker(AttribMaker):
         definition: OpenApiDict,
         secrets_cipher: Optional[Fernet],
         k8s_get_client: Optional[Callable[[str, str], str]],
+        operator_mode: str,
     ) -> None:
         super().__init__(name, tpe, base_tpe, default, factory, definition)
         self.secrets_cipher = secrets_cipher
         self.k8s_get_client = k8s_get_client
+        self.operator_mode = operator_mode
 
     def values(
         self,

--- a/appgate/secrets.py
+++ b/appgate/secrets.py
@@ -222,6 +222,10 @@ def appgate_secret_load(
     return appgate_secret.decrypt()
 
 
+def should_load_secret(operator_mode: str):
+    return "APPGATE_SECRET_SOURCE" in os.environ and operator_mode == "appgate-operator"
+
+
 class PasswordAttribMaker(AttribMaker):
     def __init__(
         self,
@@ -276,7 +280,7 @@ class PasswordAttribMaker(AttribMaker):
                     instance_maker_config.entity_name,
                 ),
                 field=self.name,
-                load_external="APPGATE_SECRET_SOURCE" in os.environ,
+                load_external=should_load_secret(self.operator_mode),
             ),
             CustomEntityLoader(loader=set_appgate_password_metadata),
         ]

--- a/appgate/syncer/operator.py
+++ b/appgate/syncer/operator.py
@@ -70,6 +70,7 @@ def git_operator_context(
         spec_directory=Path(spec_directory) if spec_directory else None,
         secrets_key=secrets_key,
         k8s_get_secret=k8s_get_secret,
+        operator_mode="git-operator",
     )
     if not namespace:
         raise AppgateException(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -113,6 +113,7 @@ def load_test_open_api_spec(
             spec_file="test_entity.yaml",
             secrets_key=secrets_key,
             k8s_get_secret=k8s_get_secret,
+            operator_mode="appgate-operator",
         )
     return TestOpenAPI
 


### PR DESCRIPTION
When the operator runs in either git-operator or reverse-operator modes, the fields for secret/file doesn't get dumped. Therefore, there is no need to load the values of these fields onto memory - it won't get used. 

Only load the secret/file values when we are in the appgate-operator mode (which is when we push entities to an SDP)