### PR TITLE
Generate upload instructions in the PR for secrets and bytes

### DIFF
--- a/appgate/customloaders.py
+++ b/appgate/customloaders.py
@@ -62,6 +62,18 @@ class FileAttribLoader(CustomAttribLoader):
 
 
 @attrs()
+class UrlFilePathLoader(CustomLoader):
+    """
+    Loader to store the URL file path for secret and files and return a new entity
+    """
+
+    loader: Callable[[AttributesDict, Entity_T], Any] = attrib()
+
+    def load(self, values: AttributesDict, entity: Entity_T) -> Any:
+        return self.loader(values, entity)
+
+
+@attrs()
 class CustomFieldsEntityLoader(CustomLoader):
     loader: Callable[..., Any] = attrib()
     field: str = attrib()

--- a/appgate/customloaders.py
+++ b/appgate/customloaders.py
@@ -62,21 +62,6 @@ class FileAttribLoader(CustomAttribLoader):
 
 
 @attrs()
-class UrlFilePathLoader(CustomLoader):
-    """
-    Loader to store the URL file path for secret and files and return a new entity
-    """
-
-    loader: Callable[[AttributesDict, Entity_T], Any] = attrib()
-    should_load: bool = attrib()
-
-    def load(self, values: AttributesDict, entity: Entity_T) -> Any:
-        if self.should_load:
-            return self.loader(values, entity)
-        return entity
-
-
-@attrs()
 class CustomFieldsEntityLoader(CustomLoader):
     loader: Callable[..., Any] = attrib()
     field: str = attrib()

--- a/appgate/customloaders.py
+++ b/appgate/customloaders.py
@@ -46,18 +46,25 @@ class FileAttribLoader(CustomAttribLoader):
     loader: Callable[[Any], Any] = attrib()
     error: Callable[[Any], Exception] = attrib()
     field: str = attrib()
-    load_external: bool = attrib()
+    is_appgate_operator_mode: bool = attrib()
+    is_external_store_configured: bool = attrib()
+    load_external: bool = attrib(default=False)
 
     def load(self, values: AttributesDict) -> AttributesDict:
-        # Always load from the external source, ignore the value specified
-        if self.load_external:
+        # If not AppgateOperator mode, allow empty file
+        if not self.is_appgate_operator_mode:
+            values[self.field] = ""
+            return values
+
+        # Always load from the external source when mode is AppgateOperator
+        if self.is_external_store_configured:
             v = self.loader(values)
             if not v:
                 return values
             values[self.field] = v
+            return values
         else:
-            values[self.field] = ""
-        return values
+            raise self.error(values)
 
 
 @attrs()

--- a/appgate/customloaders.py
+++ b/appgate/customloaders.py
@@ -68,9 +68,12 @@ class UrlFilePathLoader(CustomLoader):
     """
 
     loader: Callable[[AttributesDict, Entity_T], Any] = attrib()
+    should_load: bool = attrib()
 
     def load(self, values: AttributesDict, entity: Entity_T) -> Any:
-        return self.loader(values, entity)
+        if self.should_load:
+            return self.loader(values, entity)
+        return entity
 
 
 @attrs()

--- a/appgate/customloaders.py
+++ b/appgate/customloaders.py
@@ -50,14 +50,13 @@ class FileAttribLoader(CustomAttribLoader):
 
     def load(self, values: AttributesDict) -> AttributesDict:
         # Always load from the external source, ignore the value specified
-        # TODO: Maybe we want a flag to override this
-        if not self.load_external:
-            raise self.error(values)
         if self.load_external:
             v = self.loader(values)
             if not v:
                 return values
             values[self.field] = v
+        else:
+            values[self.field] = ""
         return values
 
 

--- a/appgate/files.py
+++ b/appgate/files.py
@@ -74,7 +74,8 @@ def url_file_path(
     2. else if it has a target field (x-filename, x-checksum for now) use the contents
     3. else if the entity has a name, use it to compute the path url `name/fieldName`
     4. else if the entity has an id, use it to compute the path url `id/fieldName`
-    5. else raise an exception
+    5. else if entity_name, field_name, and value are not empty, try our best effort to construct URL
+    6. else raise an exception
     """
     if (v := value.get(field_name)) is not None:
         return normalize_url_file_path(v)
@@ -85,6 +86,11 @@ def url_file_path(
         return f"{normalize_url_file_path(value['name'])}/{field_name}"
     elif value.get("id"):
         return f"{value['id']}/{field_name}"
+    elif field_name and value:
+        # TODO: Figure out a way to resolve URL for entity without id or name.
+        # Temporary workaround for appliance.ntp.server.key
+        normalized_value = normalize_url_file_path("/".join(value.popitem()))
+        return f"{normalized_value}/{field_name}"
     else:
         raise AppgateFileException(
             f"Unable to generate url to get fetch file for field {field_name} for entity {entity_name}"

--- a/appgate/files.py
+++ b/appgate/files.py
@@ -246,7 +246,8 @@ class FileAttribMaker(AttribMaker):
                     f"Unable to load field {self.name} for entity {instance_maker_config.name}{name_or_id(v)}."
                 ),
                 field=self.name,
-                load_external=should_load_file(self.operator_mode),
+                is_appgate_operator_mode=self.operator_mode == "appgate-operator",
+                is_external_store_configured="APPGATE_FILE_SOURCE" in os.environ,
             ),
             CustomEntityLoader(
                 loader=lambda v, e: set_appgate_file_metadata(

--- a/appgate/files.py
+++ b/appgate/files.py
@@ -242,7 +242,8 @@ class FileAttribMaker(AttribMaker):
                     entity_name=instance_maker_config.entity_name,
                     field_name=self.name,
                     target_fields=self.target_fields,
-                )
+                ),
+                should_load=should_load_file(self.operator_mode),
             ),
         ]
         return values

--- a/appgate/files.py
+++ b/appgate/files.py
@@ -10,7 +10,7 @@ from minio import Minio  # type: ignore
 
 from appgate.customloaders import (
     FileAttribLoader,
-    UrlFilePathLoader,
+    CustomEntityLoader,
 )
 from appgate.openapi.attribmaker import AttribMaker
 from appgate.openapi.types import (
@@ -235,7 +235,7 @@ class FileAttribMaker(AttribMaker):
                 field=self.name,
                 load_external=should_load_file(self.operator_mode),
             ),
-            UrlFilePathLoader(
+            CustomEntityLoader(
                 loader=lambda v, e: set_appgate_file_metadata(
                     v,
                     e,
@@ -243,7 +243,6 @@ class FileAttribMaker(AttribMaker):
                     field_name=self.name,
                     target_fields=self.target_fields,
                 ),
-                should_load=should_load_file(self.operator_mode),
             ),
         ]
         return values

--- a/appgate/files.py
+++ b/appgate/files.py
@@ -170,7 +170,7 @@ def appgate_file_load(
 
 
 def should_load_file(operator_mode: OperatorMode) -> bool:
-    return "APPGATE_FILE_SOURCE" in os.environ and operator_mode == "appgate-operator"
+    return "APPGATE_FILE_SOURCE" in os.environ
 
 
 def _get_byte_field(entity: Entity_T, names: List[str]) -> List[str]:

--- a/appgate/files.py
+++ b/appgate/files.py
@@ -76,7 +76,8 @@ def url_file_path(
     4. else if the entity has an id, use it to compute the path url `id/fieldName`
     5. else raise an exception
     """
-    if (v := value.get(field_name)) is not None:
+    v = value.get(field_name)
+    if v is not None and isinstance(v, str):
         return normalize_url_file_path(v)
     for field in target_fields:
         if v := value.get(field):

--- a/appgate/files.py
+++ b/appgate/files.py
@@ -185,7 +185,7 @@ def appgate_file_load(
 
 
 def should_load_file(operator_mode: OperatorMode) -> bool:
-    return "APPGATE_FILE_SOURCE" in os.environ
+    return "APPGATE_FILE_SOURCE" in os.environ and operator_mode == "appgate-operator"
 
 
 def set_appgate_file_metadata(

--- a/appgate/files.py
+++ b/appgate/files.py
@@ -17,8 +17,8 @@ from appgate.openapi.types import (
     AttributesDict,
     K8S_LOADERS_FIELD_NAME,
     Entity_T,
-    PYTHON_TYPES,
 )
+from appgate.openapi.utils import get_byte_field
 from appgate.types import OperatorMode
 
 
@@ -171,27 +171,6 @@ def appgate_file_load(
 
 def should_load_file(operator_mode: OperatorMode) -> bool:
     return "APPGATE_FILE_SOURCE" in os.environ
-
-
-def _get_byte_field(entity: Entity_T, names: List[str]) -> List[str]:
-    fields = []
-    prefix = ".".join(names)
-    for a in entity.__attrs_attrs__:
-        name = getattr(a, "name")
-        mt = getattr(a, "metadata", {})
-        if mt.get("format") == "byte":
-            if prefix:
-                fields.append(f"{prefix}.{name}")
-            else:
-                fields.append(name)
-        base_type = mt.get("base_type", None)
-        if base_type and base_type not in PYTHON_TYPES:
-            fields.extend(_get_byte_field(base_type, names + [name]))
-    return fields
-
-
-def get_byte_field(entity: Entity_T) -> List[str]:
-    return _get_byte_field(entity, [])
 
 
 def set_appgate_file_metadata(orig_values, entity: Entity_T) -> Entity_T:

--- a/appgate/openapi/parser.py
+++ b/appgate/openapi/parser.py
@@ -24,7 +24,11 @@ from appgate.bytes import (
     checksum_attrib_maker,
     certificate_attrib_maker,
 )
-from appgate.customloaders import CustomFieldsEntityLoader, CustomEntityLoader
+from appgate.customloaders import (
+    CustomFieldsEntityLoader,
+    CustomEntityLoader,
+    UrlFilePathLoader,
+)
 from appgate.discriminator import (
     get_discriminator_maker_config,
     DiscriminatorAttribMaker,
@@ -176,7 +180,11 @@ class EntityClassGenerator:
                 if any(
                     map(
                         lambda el: isinstance(k8s_loader, el),
-                        {CustomFieldsEntityLoader, CustomEntityLoader},
+                        {
+                            CustomFieldsEntityLoader,
+                            CustomEntityLoader,
+                            UrlFilePathLoader,
+                        },
                     )
                 ):
                     k8s_custom_entity_loaders.append(k8s_loader)

--- a/appgate/openapi/parser.py
+++ b/appgate/openapi/parser.py
@@ -27,7 +27,6 @@ from appgate.bytes import (
 from appgate.customloaders import (
     CustomFieldsEntityLoader,
     CustomEntityLoader,
-    UrlFilePathLoader,
 )
 from appgate.discriminator import (
     get_discriminator_maker_config,
@@ -183,7 +182,6 @@ class EntityClassGenerator:
                         {
                             CustomFieldsEntityLoader,
                             CustomEntityLoader,
-                            UrlFilePathLoader,
                         },
                     )
                 ):

--- a/appgate/openapi/types.py
+++ b/appgate/openapi/types.py
@@ -140,6 +140,9 @@ class AppgateMetadata:
     from_appgate: Optional[bool] = attrib(
         default=None, repr=False, metadata={"name": "fromAppgate"}
     )
+    url_file_path: Optional[str] = attrib(
+        default=None, metadata={"name": "urlFilePath"}
+    )
 
     def with_password_values(
         self, passwords: Dict[str, Union[str, Dict[str, str]]]
@@ -148,6 +151,9 @@ class AppgateMetadata:
 
     def with_password_fields(self, fields: List[str]) -> "AppgateMetadata":
         return evolve(self, password_fields=frozenset(fields))
+
+    def with_url_file_path(self, url_file_path: str) -> "AppgateMetadata":
+        return evolve(self, url_file_path=url_file_path)
 
 
 @attrs()

--- a/appgate/openapi/utils.py
+++ b/appgate/openapi/utils.py
@@ -139,3 +139,24 @@ def _get_passwords(entity: Entity_T, names: List[str]) -> List[str]:
 
 def get_passwords(entity: Entity_T) -> List[str]:
     return _get_passwords(entity, [])
+
+
+def _get_byte_field(entity: Entity_T, names: List[str]) -> List[str]:
+    fields = []
+    prefix = ".".join(names)
+    for a in entity.__attrs_attrs__:
+        name = getattr(a, "name")
+        mt = getattr(a, "metadata", {})
+        if mt.get("format") == "byte":
+            if prefix:
+                fields.append(f"{prefix}.{name}")
+            else:
+                fields.append(name)
+        base_type = mt.get("base_type", None)
+        if base_type and base_type not in PYTHON_TYPES:
+            fields.extend(_get_byte_field(base_type, names + [name]))
+    return fields
+
+
+def get_byte_field(entity: Entity_T) -> List[str]:
+    return _get_byte_field(entity, [])

--- a/appgate/secrets.py
+++ b/appgate/secrets.py
@@ -263,7 +263,6 @@ class PasswordAttribMaker(AttribMaker):
             entity_name: str,
             field_name: str,
             target_fields: Tuple[str, ...],
-            load_external: bool,
         ) -> Entity_T:
             password_fields = get_passwords(entity)
             orig_passwords = {}
@@ -272,19 +271,17 @@ class PasswordAttribMaker(AttribMaker):
                 field_passwords.append(field)
                 if field in orig_values:
                     orig_passwords[field] = orig_values[field]
-            appgate_mt = entity.appgate_metadata.with_password_fields(
-                field_passwords
-            ).with_password_values(orig_passwords)
 
-            if load_external:
-                api_version = os.getenv("APPGATE_API_VERSION")
-                contents_field = url_file_path(
-                    orig_values, field_name, entity_name, target_fields
-                )
-                url = f"{entity_name.lower()}-{api_version}/{contents_field}"
-                appgate_mt = entity.appgate_metadata.with_password_fields(
-                    field_passwords
-                ).with_url_file_path(url)
+            api_version = os.getenv("APPGATE_API_VERSION")
+            contents_field = url_file_path(
+                orig_values, field_name, entity_name, target_fields
+            )
+            url = f"{entity_name.lower()}-{api_version}/{contents_field}"
+            appgate_mt = (
+                entity.appgate_metadata.with_password_fields(field_passwords)
+                .with_password_values(orig_passwords)
+                .with_url_file_path(url)
+            )
 
             return evolve(entity, appgate_metadata=appgate_mt)
 
@@ -308,7 +305,6 @@ class PasswordAttribMaker(AttribMaker):
                     instance_maker_config.entity_name,
                     field_name=self.name,
                     target_fields=(),
-                    load_external=should_load_secret(self.operator_mode),
                 ),
             ),
         ]
@@ -320,7 +316,6 @@ class PasswordAttribMaker(AttribMaker):
                     instance_maker_config.entity_name,
                     field_name=self.name,
                     target_fields=(),
-                    load_external=should_load_secret(self.operator_mode),
                 ),
             ),
         ]

--- a/appgate/secrets.py
+++ b/appgate/secrets.py
@@ -1,6 +1,6 @@
 import base64
 import os
-from typing import Dict, List, Union, Optional, Callable
+from typing import Dict, List, Union, Optional, Callable, Tuple
 
 from attr import evolve
 
@@ -10,9 +10,10 @@ from hvac.api.auth_methods import Kubernetes  # type: ignore
 from kubernetes.client import CoreV1Api
 
 from appgate.customloaders import (
-    CustomEntityLoader,
     CustomAttribLoader,
+    CustomEntityLoader,
 )
+from appgate.files import url_file_path
 from appgate.logger import log
 from appgate.openapi.attribmaker import AttribMaker
 from appgate.openapi.types import (
@@ -256,7 +257,14 @@ class PasswordAttribMaker(AttribMaker):
 
         # sets appgate_metadata.passwords
         # TODO: Recursive fields
-        def set_appgate_password_metadata(orig_values, entity: Entity_T) -> Entity_T:
+        def set_appgate_password_metadata(
+            orig_values,
+            entity: Entity_T,
+            entity_name: str,
+            field_name: str,
+            target_fields: Tuple[str, ...],
+            load_external: bool,
+        ) -> Entity_T:
             password_fields = get_passwords(entity)
             orig_passwords = {}
             field_passwords = []
@@ -267,6 +275,17 @@ class PasswordAttribMaker(AttribMaker):
             appgate_mt = entity.appgate_metadata.with_password_fields(
                 field_passwords
             ).with_password_values(orig_passwords)
+
+            if load_external:
+                api_version = os.getenv("APPGATE_API_VERSION")
+                contents_field = url_file_path(
+                    orig_values, field_name, entity_name, target_fields
+                )
+                url = f"{entity_name.lower()}-{api_version}/{contents_field}"
+                appgate_mt = entity.appgate_metadata.with_password_fields(
+                    field_passwords
+                ).with_url_file_path(url)
+
             return evolve(entity, appgate_metadata=appgate_mt)
 
         if "metadata" not in values:
@@ -282,10 +301,28 @@ class PasswordAttribMaker(AttribMaker):
                 field=self.name,
                 load_external=should_load_secret(self.operator_mode),
             ),
-            CustomEntityLoader(loader=set_appgate_password_metadata),
+            CustomEntityLoader(
+                loader=lambda v, e: set_appgate_password_metadata(
+                    v,
+                    e,
+                    instance_maker_config.entity_name,
+                    field_name=self.name,
+                    target_fields=(),
+                    load_external=should_load_secret(self.operator_mode),
+                ),
+            ),
         ]
         values["metadata"][APPGATE_LOADERS_FIELD_NAME] = [
-            CustomEntityLoader(loader=set_appgate_password_metadata)
+            CustomEntityLoader(
+                loader=lambda v, e: set_appgate_password_metadata(
+                    v,
+                    e,
+                    instance_maker_config.entity_name,
+                    field_name=self.name,
+                    target_fields=(),
+                    load_external=should_load_secret(self.operator_mode),
+                ),
+            ),
         ]
         return values
 

--- a/appgate/syncer/git.py
+++ b/appgate/syncer/git.py
@@ -355,17 +355,6 @@ def get_sdp_pull_request(
     return GitHubPullRequest(pr) if pr else None
 
 
-def get_commit_message(commit_state: GitCommitState, p: Path) -> str | None:
-    match commit_state.operation:
-        case "ADD":
-            return f"Added {p.relative_to(GIT_DUMP_DIR)}"
-        case "DELETE":
-            return f"Deleted {p.relative_to(GIT_DUMP_DIR)}"
-        case "MODIFY":
-            return f"Modified {p.relative_to(GIT_DUMP_DIR)}"
-    return
-
-
 def get_pull_request_body(
     commits: Dict[str, List[Tuple[str, GitCommitState]]], body: str | None
 ) -> str:
@@ -384,7 +373,7 @@ Pull request created automatically by sdp-operator
             continue
         body += f"\n  * {k}"
         for (p, o) in cs:
-            body += f"\n    - {get_commit_message(o, Path(p))}"
+            body += f"\n    - {o.get_commit_message()}"
     return body
 
 
@@ -724,18 +713,27 @@ class GitEntityClient(EntityClient):
         p.mkdir(exist_ok=True)
         file = git_dump(e, self.api_spec, p, self.resolution_conflicts)
         if register_commit:
-            self.commits.append((file, "ADD"))
+            self.commits.append(
+                (p, GitCommitState(entity=e, path=file, operation="ADD"))
+            )
         return self
 
     async def create(self, e: Entity_T) -> EntityClient:
         return await self._create(e, register_commit=True)
 
-    async def _delete(self, name: str, register_commit: bool = True) -> EntityClient:
-        p: Path = entity_path(self.repository_path, self.kind) / entity_file_name(name)
+    async def _delete(self, e: Entity_T, register_commit: bool = True) -> EntityClient:
+        p: Path = entity_path(self.repository_path, self.kind) / entity_file_name(
+            e.name
+        )
         if register_commit:
-            self.commits.append((p, "DELETE"))
+            self.commits.append(
+                (p, GitCommitState(entity=e, path=p, operation="DELETE"))
+            )
         log.info(
-            "[git-entity-client/%s] Removing file %s for entity %s", self.kind, p, name
+            "[git-entity-client/%s] Removing file %s for entity %s",
+            self.kind,
+            p,
+            e.name,
         )
         if p.exists():
             p.unlink()
@@ -744,19 +742,19 @@ class GitEntityClient(EntityClient):
                 "[git-entity-client/%s] File %s for entity %s should be deleted but it's not present",
                 self.kind,
                 p,
-                name,
+                e.name,
             )
         return self
 
     async def delete(self, e: Entity_T) -> EntityClient:
-        return await self._delete(e.name, register_commit=True)
+        return await self._delete(e, register_commit=True)
 
     async def modify(self, e: Entity_T) -> EntityClient:
         p: Path = entity_path(self.repository_path, self.kind) / entity_file_name(
             e.name
         )
-        self.commits.append((p, "MODIFY"))
-        await self._delete(e.name, register_commit=False)
+        self.commits.append((p, GitCommitState(entity=e, path=p, operation="MODIFY")))
+        await self._delete(e, register_commit=False)
         await self._create(e, register_commit=False)
         return self
 
@@ -788,7 +786,7 @@ class GitEntityClient(EntityClient):
                         p,
                     )
                     self.git_repo.git_repo.index.add([str(p)])
-            commit_message += f"\n  - {get_commit_message(o, p)}"
+            commit_message += f"\n  - {o.get_commit_message()}"
         self.git_repo.git_repo.index.commit(message=commit_message)
         cs = [(str(k), v) for (k, v) in self.commits]
         self.commits = []

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -146,8 +146,6 @@ class GitCommitState:
             case "MODIFY":
                 message += f"Modified {self.path.relative_to(GIT_DUMP_DIR)}. "
 
-        log.info("ENTITY: %s", self.entity)
-
         if self.entity.appgate_metadata.url_file_path:
             message += f"\n      - [ ] Upload the bytes/secret as `{self.entity.appgate_metadata.url_file_path}`"
 

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -126,7 +126,29 @@ APPGATE_OPERATOR_PR_LABEL_COLOR = "f213e3"
 APPGATE_OPERATOR_PR_LABEL_DESC = "Pullrequest created by sdp-operator"
 
 
-GitCommitState = Literal["ADD", "DELETE", "MODIFY"]
+GitCommitOperation = Literal["ADD", "DELETE", "MODIFY"]
+
+
+@attrs(slots=True, frozen=True)
+class GitCommitState:
+    entity: Entity_T = attrib()
+    path: Path = attrib()
+    operation: GitCommitOperation = attrib()
+
+    def get_commit_message(self) -> str:
+        message = ""
+        match self.operation:
+            case "ADD":
+                message += f"Added {self.path.relative_to(GIT_DUMP_DIR)}. "
+            case "DELETE":
+                message += f"Deleted {self.path.relative_to(GIT_DUMP_DIR)}. "
+            case "MODIFY":
+                message += f"Modified {self.path.relative_to(GIT_DUMP_DIR)}. "
+
+        if self.entity.appgate_metadata.url_file_path:
+            message += f"Please upload the contents of the file as `{self.entity.appgate_metadata.url_file_path}` to the external file storage."
+
+        return message
 
 GitVendor: TypeAlias = Literal["gitlab", "github"]
 SUPPORTED_GIT_VENDORS: List[GitVendor] = ["gitlab", "github"]

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -149,7 +149,7 @@ class GitCommitState:
         log.info("ENTITY: %s", self.entity)
 
         if self.entity.appgate_metadata.url_file_path:
-            message += f"Please upload the contents of the file as `{self.entity.appgate_metadata.url_file_path}` to the external file storage."
+            message += f"\n      - [ ] Upload the bytes/secret as `{self.entity.appgate_metadata.url_file_path}`"
 
         return message
 

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -153,6 +153,7 @@ class GitCommitState:
 
         return message
 
+
 GitVendor: TypeAlias = Literal["gitlab", "github"]
 SUPPORTED_GIT_VENDORS: List[GitVendor] = ["gitlab", "github"]
 

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -18,6 +18,7 @@ from typing import (
 )
 from attr import attrib, attrs, evolve
 
+from appgate.logger import log
 from appgate.openapi.types import (
     Entity_T,
     APISpec,
@@ -144,6 +145,8 @@ class GitCommitState:
                 message += f"Deleted {self.path.relative_to(GIT_DUMP_DIR)}. "
             case "MODIFY":
                 message += f"Modified {self.path.relative_to(GIT_DUMP_DIR)}. "
+
+        log.info("ENTITY: %s", self.entity)
 
         if self.entity.appgate_metadata.url_file_path:
             message += f"Please upload the contents of the file as `{self.entity.appgate_metadata.url_file_path}` to the external file storage."

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic
 # Versioning (https://semver.org/).
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.3"
+appVersion: "0.2.4"

--- a/k8s/operator/Chart.yaml
+++ b/k8s/operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.3
+appVersion: 0.2.4

--- a/tests/test_appgatesecrets.py
+++ b/tests/test_appgatesecrets.py
@@ -55,6 +55,7 @@ def test_write_only_password_attribute_dump():
 
 def test_write_only_password_attribute_load():
     e_data = {
+        "name": "test_write_only_password_attribute_load",
         "fieldOne": ENCRYPTED_PASSWORD,  # password
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
@@ -161,18 +162,23 @@ def test_get_appgate_secret_simple_load_no_cipher():
 
 def test_get_appgate_secret_k8s_simple_load():
     EntityTest2 = (
-        load_test_open_api_spec(secrets_key=KEY, reload=True)
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
         .entities["EntityTest2"]
         .cls
     )
     data = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_get_appgate_secret_k8s_simple_load",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     e = K8S_LOADER.load(data, None, EntityTest2)
     # Password is coming from k8s secrets
-    assert e.fieldOne == "1234567890"
+    assert e.fieldOne == "1234567890-from-k8s"
     assert e.appgate_metadata.passwords == {"fieldOne": data["fieldOne"]}
 
 
@@ -183,6 +189,7 @@ def test_get_appgate_secret_k8s_simple_load_missing_key():
         .cls
     )
     data = {
+        "name": "test_get_appgate_secret_k8s_simple_load_missing_key",
         "fieldOne": {
             "type": "k8s/secret",
             "name": "secret-storage",
@@ -198,7 +205,7 @@ def test_get_appgate_secret_k8s_simple_load_missing_key():
 
 def test_get_secret_read_entity_without_password():
     EntityTest2 = (
-        load_test_open_api_spec(secrets_key=KEY, reload=True)
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
         .entities["EntityTest2"]
         .cls
     )
@@ -217,17 +224,27 @@ def test_compare_entity_with_secrets():
     If we are missing metadata frm k8s we should always update the entity
     """
     EntityTest2 = (
-        load_test_open_api_spec(secrets_key=KEY, reload=True)
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
         .entities["EntityTest2"]
         .cls
     )
     data_1 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_with_secrets",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_with_secrets",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -240,17 +257,27 @@ def test_compare_entity_with_secrets():
 
 def test_compare_entity_with_secrets_with_metadata_1():
     EntityTest2 = (
-        load_test_open_api_spec(secrets_key=KEY, reload=True)
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
         .entities["EntityTest2"]
         .cls
     )
     data_1 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_with_secrets_with_metadata_1",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_with_secrets_with_metadata_1",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -269,7 +296,12 @@ def test_compare_entity_with_secrets_with_metadata_1():
     assert e1 == e2
 
     data_2 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_with_secrets_with_metadata_1",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field different",
         "created": "2020-09-10T12:20:14Z",
@@ -281,17 +313,27 @@ def test_compare_entity_with_secrets_with_metadata_1():
 
 def test_compare_entity_with_secrets_with_metadata_2():
     EntityTest2 = (
-        load_test_open_api_spec(secrets_key=KEY, reload=True)
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
         .entities["EntityTest2"]
         .cls
     )
     data_1 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_with_secrets_with_metadata_2",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_with_secrets_with_metadata_2",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -310,17 +352,27 @@ def test_compare_entity_with_secrets_with_metadata_2():
 
 def test_compare_entity_with_secrets_with_metadata_3():
     EntityTest2 = (
-        load_test_open_api_spec(secrets_key=KEY, reload=True)
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
         .entities["EntityTest2"]
         .cls
     )
     data_1 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_with_secrets_with_metadata_3",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_with_secrets_with_metadata_3",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -339,17 +391,27 @@ def test_compare_entity_with_secrets_with_metadata_3():
 
 def test_compare_entity_with_secrets_with_metadata_4():
     EntityTest2 = (
-        load_test_open_api_spec(secrets_key=KEY, reload=True)
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
         .entities["EntityTest2"]
         .cls
     )
     data_1 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_with_secrets_with_metadata_4",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_with_secrets_with_metadata_4",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -368,19 +430,29 @@ def test_compare_entity_with_secrets_with_metadata_4():
 
 def test_compare_entity_without_secrets_and_metadata():
     EntityTest2WihoutPassword = (
-        load_test_open_api_spec(secrets_key=KEY, reload=True)
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
         .entities["EntityTest2WihoutPassword"]
         .cls
     )
     data_1 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_without_secrets_and_metadata",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
         "updated": "2020-09-10T12:20:14Z",
     }
     data_2 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entity_without_secrets_and_metadata",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -402,7 +474,11 @@ def test_compare_entity_without_secrets_and_metadata():
 @patch.dict(os.environ, {"APPGATE_SECRET_SOURCE": "vault"})
 @patch.dict(os.environ, {"APPGATE_API_VERSION": "v18"})
 def test_load_vault_secret():
-    EntityTest = load_test_open_api_spec(reload=True).entities["EntityTest2"].cls
+    EntityTest = (
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        .entities["EntityTest2"]
+        .cls
+    )
 
     data_without_password = {
         "name": "vault_secret_foo",

--- a/tests/test_appgatesecrets.py
+++ b/tests/test_appgatesecrets.py
@@ -161,22 +161,18 @@ def test_get_appgate_secret_simple_load_no_cipher():
 
 def test_get_appgate_secret_k8s_simple_load():
     EntityTest2 = (
-        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        load_test_open_api_spec(secrets_key=KEY, reload=True)
         .entities["EntityTest2"]
         .cls
     )
     data = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     e = K8S_LOADER.load(data, None, EntityTest2)
     # Password is coming from k8s secrets
-    assert e.fieldOne == "1234567890-from-k8s"
+    assert e.fieldOne == "1234567890"
     assert e.appgate_metadata.passwords == {"fieldOne": data["fieldOne"]}
 
 
@@ -202,11 +198,12 @@ def test_get_appgate_secret_k8s_simple_load_missing_key():
 
 def test_get_secret_read_entity_without_password():
     EntityTest2 = (
-        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        load_test_open_api_spec(secrets_key=KEY, reload=True)
         .entities["EntityTest2"]
         .cls
     )
     data = {
+        "name": "test_get_secret_read_entity_without_password",
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
@@ -220,25 +217,17 @@ def test_compare_entity_with_secrets():
     If we are missing metadata frm k8s we should always update the entity
     """
     EntityTest2 = (
-        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        load_test_open_api_spec(secrets_key=KEY, reload=True)
         .entities["EntityTest2"]
         .cls
     )
     data_1 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -251,25 +240,17 @@ def test_compare_entity_with_secrets():
 
 def test_compare_entity_with_secrets_with_metadata_1():
     EntityTest2 = (
-        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        load_test_open_api_spec(secrets_key=KEY, reload=True)
         .entities["EntityTest2"]
         .cls
     )
     data_1 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -288,11 +269,7 @@ def test_compare_entity_with_secrets_with_metadata_1():
     assert e1 == e2
 
     data_2 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field different",
         "created": "2020-09-10T12:20:14Z",
@@ -304,25 +281,17 @@ def test_compare_entity_with_secrets_with_metadata_1():
 
 def test_compare_entity_with_secrets_with_metadata_2():
     EntityTest2 = (
-        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        load_test_open_api_spec(secrets_key=KEY, reload=True)
         .entities["EntityTest2"]
         .cls
     )
     data_1 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -341,25 +310,17 @@ def test_compare_entity_with_secrets_with_metadata_2():
 
 def test_compare_entity_with_secrets_with_metadata_3():
     EntityTest2 = (
-        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        load_test_open_api_spec(secrets_key=KEY, reload=True)
         .entities["EntityTest2"]
         .cls
     )
     data_1 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -378,25 +339,17 @@ def test_compare_entity_with_secrets_with_metadata_3():
 
 def test_compare_entity_with_secrets_with_metadata_4():
     EntityTest2 = (
-        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        load_test_open_api_spec(secrets_key=KEY, reload=True)
         .entities["EntityTest2"]
         .cls
     )
     data_1 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -415,27 +368,19 @@ def test_compare_entity_with_secrets_with_metadata_4():
 
 def test_compare_entity_without_secrets_and_metadata():
     EntityTest2WihoutPassword = (
-        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        load_test_open_api_spec(secrets_key=KEY, reload=True)
         .entities["EntityTest2WihoutPassword"]
         .cls
     )
     data_1 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
         "updated": "2020-09-10T12:20:14Z",
     }
     data_2 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -457,11 +402,7 @@ def test_compare_entity_without_secrets_and_metadata():
 @patch.dict(os.environ, {"APPGATE_SECRET_SOURCE": "vault"})
 @patch.dict(os.environ, {"APPGATE_API_VERSION": "v18"})
 def test_load_vault_secret():
-    EntityTest = (
-        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
-        .entities["EntityTest2"]
-        .cls
-    )
+    EntityTest = load_test_open_api_spec(reload=True).entities["EntityTest2"].cls
 
     data_without_password = {
         "name": "vault_secret_foo",

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -735,6 +735,7 @@ def test_appgate_metadata_secrets_dump_from_appgate():
     api_spec = load_test_open_api_spec(secrets_key=None, reload=True)
     EntityTest2 = api_spec.entities["EntityTest2"].cls
     e1_data = {
+        "name": "test_appgate_metadata_secrets_dump_from_appgate",
         "fieldThree": "this is a field",
     }
     e1 = APPGATE_LOADER.load(e1_data, None, EntityTest2)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -34,6 +34,8 @@ from tests.utils import (
     api_spec,
     entities,
     new_file_source,
+    KEY,
+    ENCRYPTED_PASSWORD,
 )
 
 
@@ -2083,26 +2085,14 @@ def test_compare_plan_entity_pem():
 
 
 def test_compare_entities_generation_changed():
-    EntityTest2 = (
-        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
-        .entities["EntityTest2"]
-        .cls
-    )
+    EntityTest2 = load_test_open_api_spec(reload=True).entities["EntityTest2"].cls
     data_1 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -2129,26 +2119,14 @@ def test_compare_entities_generation_changed():
 
 
 def test_compare_entities_updated_changed():
-    EntityTest2 = (
-        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
-        .entities["EntityTest2"]
-        .cls
-    )
+    EntityTest2 = load_test_open_api_spec(reload=True).entities["EntityTest2"].cls
     data_1 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": {
-            "type": "k8s/secret",
-            "name": "secret-storage-1",
-            "key": "field-one",
-        },
+        "fieldOne": ENCRYPTED_PASSWORD,
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -34,8 +34,6 @@ from tests.utils import (
     api_spec,
     entities,
     new_file_source,
-    KEY,
-    ENCRYPTED_PASSWORD,
 )
 
 
@@ -2085,14 +2083,28 @@ def test_compare_plan_entity_pem():
 
 
 def test_compare_entities_generation_changed():
-    EntityTest2 = load_test_open_api_spec(reload=True).entities["EntityTest2"].cls
+    EntityTest2 = (
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        .entities["EntityTest2"]
+        .cls
+    )
     data_1 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entities_generation_changed",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entities_generation_changed",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",
@@ -2119,14 +2131,28 @@ def test_compare_entities_generation_changed():
 
 
 def test_compare_entities_updated_changed():
-    EntityTest2 = load_test_open_api_spec(reload=True).entities["EntityTest2"].cls
+    EntityTest2 = (
+        load_test_open_api_spec(reload=True, k8s_get_secret=_k8s_get_secret)
+        .entities["EntityTest2"]
+        .cls
+    )
     data_1 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entities_updated_changed",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
     }
     data_2 = {
-        "fieldOne": ENCRYPTED_PASSWORD,
+        "name": "test_compare_entities_updated_changed",
+        "fieldOne": {
+            "type": "k8s/secret",
+            "name": "secret-storage-1",
+            "key": "field-one",
+        },
         "fieldTwo": "this is write only",
         "fieldThree": "this is a field",
         "created": "2020-09-10T12:20:14Z",


### PR DESCRIPTION
## Description
Added upload instructions to entity that needs to be loaded from an external source. 

When computing the commit message for each entity, we check if `appgate_metadata["url_file_path"] is set. If it is set, print instructions specifying what path to upload the file/secret contents of the external storage. 

I'm using `url_file_path()` which is also used by the loader to figure out what URL to fetch the contents. 

![Screenshot 2023-02-21 at 4 19 47 PM](https://user-images.githubusercontent.com/7606627/220460985-983817a9-56b6-467a-b967-9c32323f8491.png)

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/operator/Chart.yaml](../k8s/operator/Chart.yaml)
