### PR TITLE
Add ClientProfile as a supported entity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ check-fmt:
 test:
 	$(PYTHON3) -m pytest -p no:cacheprovider tests
 
+dump-crd:
+	docker build -f docker/Dockerfile -t localhost:5000/sdp-operator .
+	docker run -v ${PWD}:/build --rm -it --entrypoint bash localhost:5000/sdp-operator ./run.sh --spec-directory /root/api_specs/$(VERSION) dump-crd --file /build/k8s/crd/templates/$(VERSION).yaml
+	echo '{{ if eq .Values.version "$(VERSION)" }}' | cat - k8s/crd/templates/$(VERSION).yaml > temp && mv temp k8s/crd/templates/$(VERSION).yaml
+	echo '{{ end }}' >> k8s/crd/templates/$(VERSION).yaml
+
 docker-build-image:
 	docker build -f docker/Dockerfile-build . -t sdp-operator-builder
 

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,13 @@ clean-cache:
 	find appgate -name "__pycache__" -print | xargs rm -r $1
 
 .PHONY: pip-compile
-pip-compile:
-	rm -rf venv
-	${PYTHON3} -m venv venv
+pip-compile: docker-build-image
+	docker run --rm -it -v ${PWD}:/build sdp-operator-builder make _pip-compile
+
+_pip-compile:
+	$(PYTHON3) -m venv venv
 	. venv/bin/activate && ${PYTHON3} -m pip install pip-tools && pip-compile requirements.in
+	rm -rf venv
 
 clean:
 	rm -rf api_specs

--- a/appgate/openapi/types.py
+++ b/appgate/openapi/types.py
@@ -35,6 +35,7 @@ SPEC_ENTITIES = {
     "/administrative-roles": "AdministrativeRole",
     "/device-scripts": "DeviceScript",
     "/client-connections": "ClientConnection",
+    "/client-profiles": "ClientProfile",
     "/global-settings": "GlobalSettings",
     "/appliances": "Appliance",
     "/criteria-scripts": "CriteriaScripts",

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic
 # Versioning (https://semver.org/).
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.4"
+appVersion: "0.2.5"

--- a/k8s/crd/templates/v16.yaml
+++ b/k8s/crd/templates/v16.yaml
@@ -939,8 +939,10 @@ spec:
                         default: ''
                         type: string
                       backgroundImage:
+                        default: ''
                         type: string
                       logo:
+                        default: ''
                         type: string
                       text:
                         default: ''

--- a/k8s/crd/templates/v17.yaml
+++ b/k8s/crd/templates/v17.yaml
@@ -2164,6 +2164,51 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: clientprofiles.v17.sdp.appgate.com
+spec:
+  group: v17.sdp.appgate.com
+  names:
+    kind: ClientProfile
+    plural: clientprofiles
+    shortNames:
+    - cli
+    singular: clientprofile
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              hostname:
+                default: ''
+                type: string
+              identityProviderName:
+                type: string
+              name:
+                type: string
+              notes:
+                default: ''
+                type: string
+              spaKeyName:
+                type: string
+              tags:
+                items:
+                  type: string
+                type: array
+            required:
+            - name
+            - spaKeyName
+            - identityProviderName
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: clientconnections.v17.sdp.appgate.com
 spec:
   group: v17.sdp.appgate.com
@@ -2171,7 +2216,7 @@ spec:
     kind: ClientConnection
     plural: clientconnections
     shortNames:
-    - cli
+    - clt
     singular: clientconnection
   scope: Namespaced
   versions:

--- a/k8s/crd/templates/v17.yaml
+++ b/k8s/crd/templates/v17.yaml
@@ -922,8 +922,10 @@ spec:
                         default: ''
                         type: string
                       backgroundImage:
+                        default: ''
                         type: string
                       logo:
+                        default: ''
                         type: string
                       text:
                         default: ''

--- a/k8s/crd/templates/v18.yaml
+++ b/k8s/crd/templates/v18.yaml
@@ -962,8 +962,10 @@ spec:
                         default: ''
                         type: string
                       backgroundImage:
+                        default: ''
                         type: string
                       logo:
+                        default: ''
                         type: string
                       text:
                         default: ''

--- a/k8s/crd/templates/v18.yaml
+++ b/k8s/crd/templates/v18.yaml
@@ -2248,6 +2248,51 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: clientprofiles.v18.sdp.appgate.com
+spec:
+  group: v18.sdp.appgate.com
+  names:
+    kind: ClientProfile
+    plural: clientprofiles
+    shortNames:
+    - cli
+    singular: clientprofile
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              exported:
+                format: date-time
+                type: string
+              hostname:
+                default: ''
+                type: string
+              identityProviderName:
+                type: string
+              name:
+                type: string
+              notes:
+                default: ''
+                type: string
+              tags:
+                items:
+                  type: string
+                type: array
+            required:
+            - name
+            - identityProviderName
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: clientconnections.v18.sdp.appgate.com
 spec:
   group: v18.sdp.appgate.com
@@ -2255,7 +2300,7 @@ spec:
     kind: ClientConnection
     plural: clientconnections
     shortNames:
-    - cli
+    - clt
     singular: clientconnection
   scope: Namespaced
   versions:

--- a/k8s/operator/Chart.yaml
+++ b/k8s/operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.4
+appVersion: 0.2.5

--- a/k8s/operator/templates/rbac.yaml
+++ b/k8s/operator/templates/rbac.yaml
@@ -29,6 +29,7 @@ rules:
       - globalsettingss
       - clientconnections
       - serviceusers
+      - clientprofiles
 {{- if .Values.sdp.sdpOperator.reverseMode }}
     verbs: ["get", "create", "patch", "watch", "list", "delete"]
 {{- else }}

--- a/tests/resources/entity/v18/clientprofile.yaml
+++ b/tests/resources/entity/v18/clientprofile.yaml
@@ -1,0 +1,7 @@
+apiVersion: v18.sdp.appgate.com/v1
+kind: ClientProfile
+metadata:
+  name: test
+spec:
+  identityProviderName: local
+  name: test


### PR DESCRIPTION
## Description
Add `ClientProfile` as an entity. ClientConnection was deprecated in favor of ClientProfile from v17.

I added a make command to ease the CRD helm chart generation. It runs dump-crd from the docker image and prepends/appends the necessary helm if statement. 

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/operator/Chart.yaml](../k8s/operator/Chart.yaml)
