### PR TITLE
Add support for one-shot mode

### DIFF
--- a/appgate/types.py
+++ b/appgate/types.py
@@ -82,6 +82,7 @@ __all__ = [
     "APPGATE_OPERATOR_PR_LABEL_DESC",
     "GIT_REPOSITORY_MAIN_BRANCH",
     "GIT_REPOSITORY_MAIN_BRANCH_ENV",
+    "ONE_SHOT_MODE_ENV",
 ]
 
 BUILTIN_TAGS = frozenset({"builtin"})
@@ -97,6 +98,7 @@ CLEANUP_ENV = "APPGATE_OPERATOR_CLEANUP"
 NAMESPACE_ENV = "APPGATE_OPERATOR_NAMESPACE"
 TWO_WAY_SYNC_ENV = "APPGATE_OPERATOR_TWO_WAY_SYNC"
 SPEC_DIR_ENV = "APPGATE_OPERATOR_SPEC_DIRECTORY"
+ONE_SHOT_MODE_ENV = "APPGATE_OPERATOR_ONE_SHOT_MODE"
 APPGATE_SECRETS_KEY = "APPGATE_OPERATOR_FERNET_KEY"
 APPGATE_MT_CONFIGMAP_ENV = "APPGATE_OPERATOR_CONFIG_MAP"
 APPGATE_SSL_NO_VERIFY = "APPGATE_OPERATOR_SSL_NO_VERIFY"
@@ -193,6 +195,7 @@ class AppgateOperatorArguments:
     cafile: Optional[Path] = attrib(default=None)
     device_id: Optional[str] = attrib(default=None)
     reverse_mode: bool = attrib(default=False)
+    oneshot_mode: bool = attrib(default=False)
 
 
 @attrs(slots=True, frozen=True)

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -418,6 +418,7 @@ class AppgateOperatorContext:
     api_spec: APISpec = attrib()
     metadata_configmap: str = attrib()
     reverse_mode: bool = attrib()
+    one_shot_mode: bool = attrib(default=False)
     # target tags if specified tells which entities do we want to work on
     target_tags: Optional[FrozenSet[str]] = attrib(default=None)
     # builtin tags are the entities that we consider builtin

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic
 # Versioning (https://semver.org/).
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.4"
+appVersion: 0.2.5

--- a/k8s/operator/Chart.yaml
+++ b/k8s/operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.4
+appVersion: 0.2.5

--- a/k8s/operator/templates/deployment.yaml
+++ b/k8s/operator/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
             {{- end }}
             - name: APPGATE_OPERATOR_DRY_RUN
               value: "{{ .Values.sdp.sdpOperator.dryRun }}"
+            - name: APPGATE_OPERATOR_ONE_SHOT_MODE
+              value: "{{ .Values.sdp.sdpOperator.oneshotMode }}"
             - name: APPGATE_OPERATOR_CLEANUP
               value: "{{ .Values.sdp.sdpOperator.cleanup }}"
             - name: APPGATE_OPERATOR_TWO_WAY_SYNC

--- a/k8s/operator/values.yaml
+++ b/k8s/operator/values.yaml
@@ -30,6 +30,7 @@ sdp:
     deviceId: ""
     secret: ""
     reverseMode: false
+    oneshotMode: false
     version: v18
     logLevel: info
     timeout: 30


### PR DESCRIPTION
## Description

This PR implements one-shot mode in operator (only sdpOperator supports this mode and it can not be combined with reverse mode).

When running the operator in one-shot mode it will iterate only once in the operator loop. It will read the desired state from k8s, it will compute a plan and apply it. Once it has been applied the operator will exit.

The recommended way of running the flow is:

 1. Create the entities we want to sync in the ns
 2. Deploy a job running the sdp-operator in one-shot mode

## Checklist
- [ ] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [ ] Bump `.version` and `.appVersion` in [k8s/operator/Chart.yaml](../k8s/operator/Chart.yaml)
