### PR TITLE
Run oneshot-mode as Job

### DIFF
--- a/k8s/operator/templates/deployment.yaml
+++ b/k8s/operator/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if has "sdp-operator" .Values.sdp.operators }}
+{{- if and (has "sdp-operator" .Values.sdp.operators) (eq .Values.sdp.sdpOperator.oneshotMode false) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -72,8 +72,6 @@ spec:
             {{- end }}
             - name: APPGATE_OPERATOR_DRY_RUN
               value: "{{ .Values.sdp.sdpOperator.dryRun }}"
-            - name: APPGATE_OPERATOR_ONE_SHOT_MODE
-              value: "{{ .Values.sdp.sdpOperator.oneshotMode }}"
             - name: APPGATE_OPERATOR_CLEANUP
               value: "{{ .Values.sdp.sdpOperator.cleanup }}"
             - name: APPGATE_OPERATOR_TWO_WAY_SYNC

--- a/k8s/operator/templates/job.yaml
+++ b/k8s/operator/templates/job.yaml
@@ -1,0 +1,112 @@
+{{ if .Values.sdp.sdpOperator.oneshotMode }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "sdp-operator.fullname" . }}-one-shot
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "sdp-operator.serviceAccountName" . }}-sdp
+      containers:
+        - name: {{ .Chart.Name }}-one-shot
+          env:
+            - name: APPGATE_API_VERSION
+              value: {{ .Values.sdp.sdpOperator.version }}
+            - name: APPGATE_OPERATOR_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: APPGATE_OPERATOR_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "sdp-operator.secret" .) .Values.sdp.sdpOperator.secret }}
+                  key: appgate-operator-user
+            - name: APPGATE_OPERATOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "sdp-operator.secret" .) .Values.sdp.sdpOperator.secret }}
+                  key: appgate-operator-password
+            - name: APPGATE_OPERATOR_HOST
+              value: {{ required "A valid .Values.sdp.sdpOperator.host entry is required!" .Values.sdp.sdpOperator.host }}
+            - name: APPGATE_OPERATOR_DEVICE_ID
+              value: {{ required "A valid .Values.sdp.sdpOperator.deviceId entry is required!" .Values.sdp.sdpOperator.deviceId }}
+            - name: APPGATE_OPERATOR_LOG_LEVEL
+              value: "{{ .Values.sdp.sdpOperator.logLevel }}"
+            - name: APPGATE_OPERATOR_SPEC_DIRECTORY
+              value: /root/api_specs/{{ required "A valid .Values.sdp.sdpOperator.version entry is required!" .Values.sdp.sdpOperator.version }}
+            - name: APPGATE_OPERATOR_TIMEOUT
+              value: "{{ .Values.sdp.sdpOperator.timeout }}"
+            - name: APPGATE_OPERATOR_ONE_SHOT_MODE
+              value: "{{ .Values.sdp.sdpOperator.oneshotMode }}"
+            {{- with .Values.sdp.sdpOperator.targetTags }}
+            - name: APPGATE_OPERATOR_TARGET_TAGS
+              value: "{{ join "," . }}"
+            {{- end }}
+            {{- with .Values.sdp.sdpOperator.excludeTags }}
+            - name: APPGATE_OPERATOR_EXCLUDE_TAGS
+              value: "{{ join "," . }}"
+            {{- end }}
+            {{- with .Values.sdp.sdpOperator.builtinTags }}
+            - name: APPGATE_OPERATOR_BUILTIN_TAGS
+              value: "{{ join "," . }}"
+            {{- end }}
+            - name: APPGATE_OPERATOR_DRY_RUN
+              value: "{{ .Values.sdp.sdpOperator.dryRun }}"
+            - name: APPGATE_OPERATOR_CLEANUP
+              value: "{{ .Values.sdp.sdpOperator.cleanup }}"
+            - name: APPGATE_OPERATOR_TWO_WAY_SYNC
+              value: "{{ .Values.sdp.sdpOperator.twoWaySync }}"
+            - name: APPGATE_OPERATOR_SSL_NO_VERIFY
+              value: "{{ .Values.sdp.sdpOperator.sslNoVerify }}"
+            {{- with .Values.sdp.sdpOperator.caCert }}
+            - name: APPGATE_OPERATOR_CACERT
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.sdp.sdpOperator.fernetKey }}
+            - name: APPGATE_OPERATOR_FERNET_KEY
+              value: "{{ . }}"
+            {{- end }}
+            {{- if .Values.sdp.externalSecret.enabled }}
+            - name: APPGATE_SECRET_SOURCE
+              value: {{ .Values.sdp.externalSecret.type }}
+            {{- if eq .Values.sdp.externalSecret.type "vault" }}
+            - name: APPGATE_VAULT_ADDRESS
+              value: {{ .Values.sdp.externalSecret.source.vault.address }}
+            - name: APPGATE_VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.sdp.externalSecret.source.vault.tokenSecret }}
+                  key: vault-token
+            - name: APPGATE_VAULT_SSL_NO_VERIFY
+              value: {{ .Values.sdp.externalSecret.source.vault.sslNoVerify | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.sdp.externalFile.enabled }}
+            - name: APPGATE_FILE_SOURCE
+              value: {{ .Values.sdp.externalFile.type }}
+            {{- if eq .Values.sdp.externalFile.type "http" }}
+            - name: APPGATE_FILE_HTTP_ADDRESS
+              value: {{ .Values.sdp.externalFile.source.http.address }}
+            {{- end }}
+            {{- if eq .Values.sdp.externalFile.type "s3" }}
+            - name: APPGATE_FILE_S3_ADDRESS
+              value: {{ .Values.sdp.externalFile.source.s3.address }}
+            - name: APPGATE_FILE_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.sdp.externalFile.source.s3.keySecret }}
+                  key: access-key
+            - name: APPGATE_FILE_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.sdp.externalFile.source.s3.keySecret }}
+                  key: secret-key
+            - name: APPGATE_FILE_S3_SSL_NO_VERIFY
+              value: {{ .Values.sdp.externalFile.source.s3.sslNoVerify | quote }}
+            {{- end }}
+            {{- end }}
+          image: "{{ .Values.sdp.sdpOperator.image.repository }}/sdp-operator:{{ default .Chart.AppVersion .Values.sdp.sdpOperator.image.tag}}"
+          imagePullPolicy: {{ .Values.sdp.sdpOperator.image.pullPolicy }}
+          args:
+            - appgate-operator
+{{- end }}


### PR DESCRIPTION
## Description
If `.Values.sdp.sdpOperator.oneshotMode` is enabled, run the operator as a Job.

To be honest, it feels a little clunky to deploy a Job as a helm chart because the pod will complete. But wrapping it in a helm chart is the easiest way to pass operator configuration as a values file and to handle serviceaccounts and roles-based access control. 

@thomascellerier @lepiolet What do you guys think?  