### PR TITLE
Add constraints to run python 3.10 pip-compile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "pip-compile": {
     "fileMatch": ["(^|/)requirements\\.in$"]
   },
-  "enabledManagers": ["pip-compile"]
+  "enabledManagers": ["pip-compile"],
+  "constraints": {
+    "python": "==3.10"
+  }
 }


### PR DESCRIPTION
## Description
Restrict to python `3.10`
