### PR TITLE
Harden sdp-operator image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ COPY requirements.txt /appgate
 
 RUN apt-get update && \
     apt-get install git --yes && \
+    apt-get remove curl && \
     apt-get clean && \
     apt-get autoclean && \
     python3 -m venv /appgate/venv && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && \
     apt-get remove curl && \
     apt-get clean && \
     apt-get autoclean && \
+    dpkg -r --force-all apt apt-get && \
+    dpkg -r --force-all debconf dpkg && \
     python3 -m venv /appgate/venv && \
     /appgate/venv/bin/pip install --upgrade pip && \
     /appgate/venv/bin/pip install -r /appgate/requirements.txt && \

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic
 # Versioning (https://semver.org/).
-version: 0.3.6
+version: 0.3.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.6
+appVersion: 0.3.7

--- a/k8s/operator/Chart.yaml
+++ b/k8s/operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.6
+version: 0.3.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.6
+appVersion: 0.3.7

--- a/requirements.in
+++ b/requirements.in
@@ -7,5 +7,5 @@ typedload == 2.26
 GitPython ~= 3.0
 PyGitHub ~= 1.0
 hvac ~= 1.0
-minio ~= 7.0
+minio ~= 7.2
 python-gitlab ~= 3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,10 @@ aiosignal==1.3.1
     # via aiohttp
 apischema==0.18.0
     # via -r requirements.in
+argon2-cffi==23.1.0
+    # via minio
+argon2-cffi-bindings==21.2.0
+    # via argon2-cffi
 async-timeout==4.0.3
     # via aiohttp
 attrs==23.1.0
@@ -25,6 +29,7 @@ certifi==2023.7.22
     #   requests
 cffi==1.16.0
     # via
+    #   argon2-cffi-bindings
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.0
@@ -55,7 +60,7 @@ idna==3.4
     #   yarl
 kubernetes==28.1.0
     # via -r requirements.in
-minio==7.1.17
+minio==7.2.0
     # via -r requirements.in
 multidict==6.0.4
     # via
@@ -73,6 +78,8 @@ pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
     # via cffi
+pycryptodome==3.19.0
+    # via minio
 pygithub==1.59.1
     # via -r requirements.in
 pyhcl==0.4.5
@@ -109,7 +116,7 @@ smmap==5.0.1
     # via gitdb
 typedload==2.26
     # via -r requirements.in
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   kubernetes
     #   minio


### PR DESCRIPTION
## Description
Address the following policy violation:
- Fixable CVE-2022-40897 (CVSS 5.9) (severity Moderate) found in component 'setuptools' (version 65.5.0), resolved by version 65.5.1
```
appgate@sdp-operator-sdp-6d6d5655b5-6xhvd:/appgate$ python3 -c "import setuptools; print(setuptools.__version__)"
65.5.1
```
- Fixable CVE-2023-45803 (CVSS 4.2) (severity Moderate) found in component 'urllib3' (version 1.26.17), resolved by version 1.26.18
```
$ cat requirements.txt | grep urllib3
urllib3==1.26.18
```
- Image includes component 'curl' (version 7.88.1-10+deb12u4)
```
appgate@sdp-operator-sdp-6d6d5655b5-6xhvd:/appgate$ curl
bash: curl: command not found
```
- Image includes component 'apt' (version 2.6.1)
```
appgate@sdp-operator-sdp-6d6d5655b5-6xhvd:/appgate$ apt-get
bash: apt-get: command not found
```
- Image includes component 'dpkg' (version 1.21.22)
```
appgate@sdp-operator-sdp-6d6d5655b5-6xhvd:/appgate$ dpkg
bash: dpkg: command not found
```


## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/operator/Chart.yaml](../k8s/operator/Chart.yaml)
