### PR TITLE
Upgrade package version to address vulnerabilities

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ COPY requirements.txt /appgate
 RUN apt-get update && \
     apt-get install --yes \
         git \
-        # CVE-2023-5981
+        # TODO: Remove when CVE-2023-5981 is resolved in upstream debian
         libgnutls30=3.7.9-2+deb12u1 && \
     apt-get remove curl && \
     apt-get clean && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,10 @@ USER root
 COPY requirements.txt /appgate
 
 RUN apt-get update && \
-    apt-get install git --yes && \
+    apt-get install --yes \
+        git \
+        # CVE-2023-5981
+        libgnutls30=3.7.9-2+deb12u1 && \
     apt-get remove curl && \
     apt-get clean && \
     apt-get autoclean && \

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic
 # Versioning (https://semver.org/).
-version: 0.3.7
+version: 0.3.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.7
+appVersion: 0.3.8

--- a/k8s/operator/Chart.yaml
+++ b/k8s/operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.7
+version: 0.3.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.7
+appVersion: 0.3.8

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 aiohttp ~= 3.0
 apischema ~= 0.18
 attrs ~= 23.0
-cryptography ~= 41.0
+cryptography ~= 41.0.6
 kubernetes ~= 28.0
 typedload == 2.26
 GitPython ~= 3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ charset-normalizer==3.3.0
     # via
     #   aiohttp
     #   requests
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements.in
     #   pyjwt


### PR DESCRIPTION
## Description
- Bump cryptography to 41.0.7
- Bump libgnutls to 3.7.9-2+deb12u1

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/operator/Chart.yaml](../k8s/operator/Chart.yaml)
