### PR TITLE
Don't reference entities that are filtered when resolving the ordering

### DIFF
--- a/appgate/state.py
+++ b/appgate/state.py
@@ -498,7 +498,13 @@ class AppgatePlan:
         return any(v.needs_apply for v in self.entities_plan.values())
 
     def ordered_entities_plan(self, api_spec: APISpec) -> Iterator[Tuple[str, Plan]]:
-        return map(lambda k: (k, self.entities_plan[k]), api_spec.entities_sorted)
+        return filter(
+            None,
+            map(
+                lambda k: (k, v) if (v := self.entities_plan.get(k)) else None,
+                api_spec.entities_sorted,
+            ),
+        )
 
     @cached_property
     def errors(self) -> List[str]:

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic
 # Versioning (https://semver.org/).
-version: 0.3.8
+version: 0.3.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.8
+appVersion: 0.3.9

--- a/k8s/operator/Chart.yaml
+++ b/k8s/operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.8
+version: 0.3.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.8
+appVersion: 0.3.9


### PR DESCRIPTION
## Description

We need to ignore entities that have been filtered out since there is no classes for them

## Checklist
- [X] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [X] Bump `.version` and `.appVersion` in [k8s/operator/Chart.yaml](../k8s/operator/Chart.yaml)
