### PR TITLE
[SA-23422] Add ability to configure path for known host file

### DIFF
--- a/appgate/syncer/operator.py
+++ b/appgate/syncer/operator.py
@@ -46,6 +46,8 @@ from appgate.types import (
     GIT_SSH_HOST_KEY_FINGERPRINT_PATH,
     GIT_DUMP_DIR_ENV,
     GIT_DUMP_DIR,
+    GIT_SSH_KNOWN_HOSTS_FILE_ENV,
+    GIT_SSH_KNOWN_HOSTS_FILE,
 )
 from appgate.openapi.types import (
     AppgateException,
@@ -114,6 +116,9 @@ def git_operator_context(
                 GIT_SSH_HOST_KEY_FINGERPRINT_PATH_ENV,
                 GIT_SSH_HOST_KEY_FINGERPRINT_PATH,
             )
+        ),
+        git_ssh_known_hosts_file=Path(
+            os.environ.get(GIT_SSH_KNOWN_HOSTS_FILE_ENV, GIT_SSH_KNOWN_HOSTS_FILE)
         ),
         git_dump_path=Path(os.environ.get(GIT_DUMP_DIR_ENV, GIT_DUMP_DIR)),
     )

--- a/appgate/types.py
+++ b/appgate/types.py
@@ -127,6 +127,8 @@ GIT_SSH_KEY_PATH_ENV = "GIT_SSH_KEY_PATH_ENV"
 GIT_SSH_KEY_PATH = "/home/appgate/git-operator/k8s/deployment.key"
 GIT_SSH_HOST_KEY_FINGERPRINT_PATH_ENV = "GIT_KEY_FINGERPRINT_PATH_ENV"
 GIT_SSH_HOST_KEY_FINGERPRINT_PATH = "/home/appgate/git-operator/k8s/fingerprint.key"
+GIT_SSH_KNOWN_HOSTS_FILE_ENV = "GIT_SSH_KNOWN_HOSTS_FILE"
+GIT_SSH_KNOWN_HOSTS_FILE = "/home/appgate/.ssh/known_hosts"
 
 APPGATE_OPERATOR_PR_LABEL_NAME = "sdp-operator"
 APPGATE_OPERATOR_PR_LABEL_COLOR = "f213e3"
@@ -455,6 +457,7 @@ class GitOperatorContext:
     git_ssh_key_path: Path = attrib()
     git_ssh_host_key_fingerprint_path: Path = attrib()
     git_dump_path: Path = attrib()
+    git_ssh_known_hosts_file: Path = attrib()
     git_strict_host_key_checking = attrib(default=True)
     target_tags: FrozenSet[str] | None = attrib(default=None)
     dry_run: bool = attrib(default=True)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,9 +7,7 @@ COPY requirements.txt /appgate
 
 RUN apt-get update && \
     apt-get install --yes \
-        git \
-        # TODO: Remove when CVE-2023-5981 is resolved in upstream debian
-        libgnutls30=3.7.9-2+deb12u1 && \
+        git && \
     apt-get remove curl && \
     apt-get clean && \
     apt-get autoclean && \

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic
 # Versioning (https://semver.org/).
-version: 0.3.9
+version: 0.3.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.9
+appVersion: 0.3.10

--- a/k8s/operator/Chart.yaml
+++ b/k8s/operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.9
+version: 0.3.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.9
+appVersion: 0.3.10

--- a/k8s/operator/templates/git-operator-deployment.yaml
+++ b/k8s/operator/templates/git-operator-deployment.yaml
@@ -117,6 +117,10 @@ spec:
             - name: GIT_KEY_FINGERPRINT_PATH_ENV
               value: {{ .Values.sdp.gitOperator.git.sshKeyFingerprintPath }}
             {{- end}}
+            {{- if .Values.sdp.gitOperator.git.sshKnownHostsFile }}
+            - name: GIT_SSH_KNOWN_HOSTS_FILE
+              value: {{ .Values.sdp.gitOperator.git.sshKnownHostsFile }}
+            {{- end}}
             {{- if .Values.sdp.gitOperator.git.clonePath }}
             - name: GIT_DUMP_PATH_ENV
               value: {{ .Values.sdp.gitOperator.git.clonePath }}

--- a/k8s/operator/values.yaml
+++ b/k8s/operator/values.yaml
@@ -125,6 +125,7 @@ sdp:
       strictHostKeyChecking: true
       sshKeyPath: ""
       sshKeyFingerprintPath: ""
+      sshKnownHostsFile: ""
       clonePath: ""
     ## @param sdp.gitOperator.image.tag The image tag of the operator.
     ## @param sdp.gitOperator.image.pullPolicy The image pull policy of the operator.


### PR DESCRIPTION
## Description
Overriding `.Values.sdp.gitOperator.git.sshKnownHostsFile` will instruct the Git Operator to write the SSH fingerprints for Github/GitLab into the path specified in this value. If the value is set, `-o UserKnownFile=<path>` is appended to the git ssh command when cloning. If the value is not provided, it will use the default known file (`/home/appgate/.ssh/known_hosts`)

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/operator/Chart.yaml](../k8s/operator/Chart.yaml)
