### PR TITLE
v20 added 'totalCount' as a  property for non-singleton entity

### DIFF
--- a/appgate/openapi/openapi.py
+++ b/appgate/openapi/openapi.py
@@ -40,7 +40,13 @@ LATEST_API_VERSION = "v20"
 SPEC_DIR = f"api_specs/{LATEST_API_VERSION}"
 K8S_API_VERSION = "apiextensions.k8s.io/v1"
 K8S_CRD_KIND = "CustomResourceDefinition"
-LIST_PROPERTIES = {"range", "data", "query", "orderBy", "descending", "filterBy"}
+
+# If the definition doesn't contain these properties, we consider that entity as singleton
+LIST_PROPERTIES: Dict[int, set] = {
+    18: {"range", "data", "query", "orderBy", "descending", "filterBy"},
+    19: {"range", "data", "query", "orderBy", "descending", "filterBy"},
+    20: {"range", "data", "query", "orderBy", "descending", "filterBy", "totalCount"},
+}
 
 
 def parse_files(
@@ -89,8 +95,12 @@ def parse_files(
             parsed_schema = get_schema
         else:
             parsed_schema = {}
+
         singleton = not all(
-            map(lambda f: f in parsed_schema.get("properties", {}), LIST_PROPERTIES)
+            map(
+                lambda f: f in parsed_schema.get("properties", {}),
+                LIST_PROPERTIES.get(api_version, {}),
+            )
         )
         parser.parse_definition(
             entity_name=entity_name,

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic
 # Versioning (https://semver.org/).
-version: 0.3.11
+version: 0.3.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.11
+appVersion: 0.3.12

--- a/k8s/operator/Chart.yaml
+++ b/k8s/operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.11
+version: 0.3.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.11
+appVersion: 0.3.12


### PR DESCRIPTION
## Description
v20 API response contains `totalCount` as a new property. Our logic to determine if an entity is a singleton was checking if the response contains the properties for a non-singleton entity. Created a version-dependent list of properties. 
