### PR TITLE
Bump packages to mitigate vulnerabilities

### DIFF
--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic
 # Versioning (https://semver.org/).
-version: 0.3.13
+version: 0.3.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.13
+appVersion: 0.3.14

--- a/k8s/operator/Chart.yaml
+++ b/k8s/operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.13
+version: 0.3.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.13
+appVersion: 0.3.14

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ attrs ~= 23.0
 cryptography ~= 41.0.6
 kubernetes ~= 28.0
 typedload == 2.26
-GitPython ~= 3.0
+GitPython ~= 3.1.43
 PyGitHub ~= 1.0
 hvac ~= 1.0
 minio ~= 7.2

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 aiohttp ~= 3.9
 apischema ~= 0.18
 attrs ~= 23.0
-cryptography ~= 41.0.6
+cryptography ~= 42.0.5
 kubernetes ~= 28.0
 typedload == 2.26
 GitPython ~= 3.1.43

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-aiohttp ~= 3.0
+aiohttp ~= 3.9
 apischema ~= 0.18
 attrs ~= 23.0
 cryptography ~= 41.0.6

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ apischema ~= 0.18
 attrs ~= 23.0
 cryptography ~= 42.0.5
 kubernetes ~= 28.0
-typedload == 2.26
+typedload == 2.27
 GitPython ~= 3.1.43
 PyGitHub ~= 1.0
 hvac ~= 1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ six==1.16.0
     #   python-dateutil
 smmap==5.0.1
     # via gitdb
-typedload==2.26
+typedload==2.27
     # via -r requirements.in
 urllib3==1.26.18
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ cffi==1.16.0
     #   pynacl
 charset-normalizer==3.3.0
     # via requests
-cryptography==41.0.7
+cryptography==42.0.5
     # via
     #   -r requirements.in
     #   pyjwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-aiohttp==3.8.5
+aiohttp==3.9.5
     # via -r requirements.in
 aiosignal==1.3.1
     # via aiohttp
@@ -14,8 +14,6 @@ argon2-cffi==23.1.0
     # via minio
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
-async-timeout==4.0.3
-    # via aiohttp
 attrs==23.1.0
     # via
     #   -r requirements.in
@@ -33,9 +31,7 @@ cffi==1.16.0
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.0
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 cryptography==41.0.7
     # via
     #   -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ frozenlist==1.4.0
     #   aiosignal
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.37
+gitpython==3.1.43
     # via -r requirements.in
 google-auth==2.23.2
     # via kubernetes


### PR DESCRIPTION
## Description
Bump the following packages:
- typedload 2.27
- cryptography 42.0.5
- gitpython 3.1.43
- aiohttp 3.9.5

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/operator/Chart.yaml](../k8s/operator/Chart.yaml)
