### PR TITLE
Default empty 'description' in Sites to empty string, not null

### DIFF
--- a/appgate/attrs.py
+++ b/appgate/attrs.py
@@ -159,7 +159,7 @@ def get_dumper(platform_type: PlatformType, api_spec: APISpec | None = None):
             if d.hidedefault:
                 if name == "_entity_metadata":
                     continue
-                if name != "notes" and (attrval is None or attrval == ""):
+                if name not in ["notes", "description"] and (attrval is None or attrval == ""):
                     continue
                 if (
                     hasattr(attr.default, "factory")

--- a/appgate/attrs.py
+++ b/appgate/attrs.py
@@ -159,7 +159,9 @@ def get_dumper(platform_type: PlatformType, api_spec: APISpec | None = None):
             if d.hidedefault:
                 if name == "_entity_metadata":
                     continue
-                if name not in ["notes", "description"] and (attrval is None or attrval == ""):
+                if name not in ["notes", "description"] and (
+                    attrval is None or attrval == ""
+                ):
                     continue
                 if (
                     hasattr(attr.default, "factory")

--- a/k8s/crd/Chart.yaml
+++ b/k8s/crd/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version. Versions are expected to follow Semantic
 # Versioning (https://semver.org/).
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.1
+appVersion: 0.4.2

--- a/k8s/operator/Chart.yaml
+++ b/k8s/operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.1
+appVersion: 0.4.2


### PR DESCRIPTION
## Description
Similar to `notes`, description should be an empty string, not null

## Checklist
- [x] Bump `.version` and `.appVersion` in [k8s/crd/Chart.yaml](../k8s/crd/Chart.yaml)
- [x] Bump `.version` and `.appVersion` in [k8s/operator/Chart.yaml](../k8s/operator/Chart.yaml)
